### PR TITLE
Automatically add catches to trips based on time period.

### DIFF
--- a/mobile/lib/catch_manager.dart
+++ b/mobile/lib/catch_manager.dart
@@ -23,6 +23,7 @@ import 'image_manager.dart';
 import 'method_manager.dart';
 import 'model/gen/anglers_log.pb.dart';
 import 'species_manager.dart';
+import 'user_preference_manager.dart';
 import 'utils/catch_utils.dart';
 import 'utils/protobuf_utils.dart';
 import 'utils/string_utils.dart';
@@ -531,7 +532,34 @@ class CatchManager extends EntityManager<Catch> {
       );
     }
 
-    return super.addOrUpdate(entity, notify: notify);
+    var result = await super.addOrUpdate(entity, notify: notify);
+
+    if (result && UserPreferenceManager.get.autoAddCatchesToTrip) {
+      await _addCatchToMatchingTrips(entity);
+    }
+
+    return result;
+  }
+
+  /// Adds [cat] to any trips whose time range contains the catch's timestamp.
+  Future<void> _addCatchToMatchingTrips(Catch cat) async {
+    var catchMs = cat.timestamp.toInt();
+    if (catchMs == 0) return;
+
+    for (var trip in _tripManager.list()) {
+      if (!trip.hasStartTimestamp() || !trip.hasEndTimestamp()) continue;
+
+      var startMs = trip.startTimestamp.toInt();
+      var endMs = trip.endTimestamp.toInt();
+
+      if (catchMs >= startMs &&
+          catchMs <= endMs &&
+          !trip.catchIds.contains(cat.id)) {
+        trip.catchIds.add(cat.id);
+        await _tripManager.addOrUpdate(trip, setImages: false);
+        _log.d("Auto-added catch ${cat.id} to trip ${trip.id}");
+      }
+    }
   }
 
   /// Returns true if a [Catch] with the given properties exists.

--- a/mobile/lib/catch_manager.dart
+++ b/mobile/lib/catch_manager.dart
@@ -543,8 +543,10 @@ class CatchManager extends EntityManager<Catch> {
 
   /// Adds [cat] to any trips whose time range contains the catch's timestamp.
   Future<void> _addCatchToMatchingTrips(Catch cat) async {
+    if (!cat.hasTimestamp()) {
+      return;
+    }
     var catchMs = cat.timestamp.toInt();
-    if (catchMs == 0) return;
 
     for (var trip in _tripManager.list()) {
       if (!trip.hasStartTimestamp() || !trip.hasEndTimestamp()) continue;

--- a/mobile/lib/l10n/gen/localizations.dart
+++ b/mobile/lib/l10n/gen/localizations.dart
@@ -1801,6 +1801,30 @@ abstract class AnglersLogLocalizations {
   /// **'Automatically set applicable fields when catches are selected.'**
   String get saveTripPageAutoSetDescription;
 
+  /// No description provided for @saveTripPageAutoAddCatchesTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Auto-add Catches'**
+  String get saveTripPageAutoAddCatchesTitle;
+
+  /// No description provided for @saveTripPageAutoAddCatchesDescription.
+  ///
+  /// In en, this message translates to:
+  /// **'Automatically add catches that fall within the trip\'\'s time period.'**
+  String get saveTripPageAutoAddCatchesDescription;
+
+  /// No description provided for @saveTripPageAutoAddCatchesPrompt.
+  ///
+  /// In en, this message translates to:
+  /// **'{numOfCatches} catches were made during this trip. Add them?'**
+  String saveTripPageAutoAddCatchesPrompt(int numOfCatches);
+
+  /// No description provided for @saveTripPageAutoAddCatchesPromptSingular.
+  ///
+  /// In en, this message translates to:
+  /// **'1 catch was made during this trip. Add it?'**
+  String get saveTripPageAutoAddCatchesPromptSingular;
+
   /// No description provided for @saveTripPageStartDate.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/gen/localizations_en.dart
+++ b/mobile/lib/l10n/gen/localizations_en.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'localizations.dart';
 
 // ignore_for_file: type=lint
@@ -984,6 +983,22 @@ class AnglersLogLocalizationsEn extends AnglersLogLocalizations {
   @override
   String get saveTripPageAutoSetDescription =>
       'Automatically set applicable fields when catches are selected.';
+
+  @override
+  String get saveTripPageAutoAddCatchesTitle => 'Auto-add Catches';
+
+  @override
+  String get saveTripPageAutoAddCatchesDescription =>
+      'Automatically add catches that fall within the trip\'s time period.';
+
+  @override
+  String saveTripPageAutoAddCatchesPrompt(int numOfCatches) {
+    return '$numOfCatches catches were made during this trip. Add them?';
+  }
+
+  @override
+  String get saveTripPageAutoAddCatchesPromptSingular =>
+      '1 catch was made during this trip. Add it?';
 
   @override
   String get saveTripPageStartDate => 'Start Date';

--- a/mobile/lib/l10n/gen/localizations_es.dart
+++ b/mobile/lib/l10n/gen/localizations_es.dart
@@ -1,6 +1,5 @@
 // ignore: unused_import
 import 'package:intl/intl.dart' as intl;
-
 import 'localizations.dart';
 
 // ignore_for_file: type=lint
@@ -988,6 +987,22 @@ class AnglersLogLocalizationsEs extends AnglersLogLocalizations {
   @override
   String get saveTripPageAutoSetDescription =>
       'Establecer automáticamente los campos aplicables cuando se seleccionen las capturas.';
+
+  @override
+  String get saveTripPageAutoAddCatchesTitle => 'Auto-add Catches';
+
+  @override
+  String get saveTripPageAutoAddCatchesDescription =>
+      'Automatically add catches that fall within the trip\'s time period.';
+
+  @override
+  String saveTripPageAutoAddCatchesPrompt(int numOfCatches) {
+    return '$numOfCatches catches were made during this trip. Add them?';
+  }
+
+  @override
+  String get saveTripPageAutoAddCatchesPromptSingular =>
+      '1 catch was made during this trip. Add it?';
 
   @override
   String get saveTripPageStartDate => 'Fecha de inicio';

--- a/mobile/lib/l10n/gen/localizations_es.dart
+++ b/mobile/lib/l10n/gen/localizations_es.dart
@@ -989,20 +989,20 @@ class AnglersLogLocalizationsEs extends AnglersLogLocalizations {
       'Establecer automáticamente los campos aplicables cuando se seleccionen las capturas.';
 
   @override
-  String get saveTripPageAutoAddCatchesTitle => 'Auto-add Catches';
+  String get saveTripPageAutoAddCatchesTitle => 'Auto-agregar capturas';
 
   @override
   String get saveTripPageAutoAddCatchesDescription =>
-      'Automatically add catches that fall within the trip\'s time period.';
+      'Agregar automáticamente las capturas que se encuentren dentro del período del viaje.';
 
   @override
   String saveTripPageAutoAddCatchesPrompt(int numOfCatches) {
-    return '$numOfCatches catches were made during this trip. Add them?';
+    return '$numOfCatches capturas se realizaron durante este viaje. ¿Agregarlas?';
   }
 
   @override
   String get saveTripPageAutoAddCatchesPromptSingular =>
-      '1 catch was made during this trip. Add it?';
+      '1 captura se realizó durante este viaje. ¿Agregarla?';
 
   @override
   String get saveTripPageStartDate => 'Fecha de inicio';

--- a/mobile/lib/l10n/localizations_en.arb
+++ b/mobile/lib/l10n/localizations_en.arb
@@ -590,6 +590,17 @@
   "saveTripPageNewTitle": "New Trip",
   "saveTripPageAutoSetTitle": "Auto-set Fields",
   "saveTripPageAutoSetDescription": "Automatically set applicable fields when catches are selected.",
+  "saveTripPageAutoAddCatchesTitle": "Auto-add Catches",
+  "saveTripPageAutoAddCatchesDescription": "Automatically add catches that fall within the trip''s time period.",
+  "saveTripPageAutoAddCatchesPrompt": "{numOfCatches} catches were made during this trip. Add them?",
+  "@saveTripPageAutoAddCatchesPrompt": {
+    "placeholders": {
+      "numOfCatches": {
+        "type": "int"
+      }
+    }
+  },
+  "saveTripPageAutoAddCatchesPromptSingular": "1 catch was made during this trip. Add it?",
   "saveTripPageStartDate": "Start Date",
   "saveTripPageStartTime": "Start Time",
   "saveTripPageStartDateTime": "Start Date and Time",

--- a/mobile/lib/l10n/localizations_es.arb
+++ b/mobile/lib/l10n/localizations_es.arb
@@ -772,6 +772,17 @@
   "saveSpeciesPageNewTitle": "Nueva especie",
   "saveTripPageAllDay": "Todo el dia",
   "saveTripPageAutoSetDescription": "Establecer automáticamente los campos aplicables cuando se seleccionen las capturas.",
+  "saveTripPageAutoAddCatchesDescription": "Agregar automáticamente las capturas que se encuentren dentro del período del viaje.",
+  "saveTripPageAutoAddCatchesPrompt": "{numOfCatches} capturas se realizaron durante este viaje. ¿Agregarlas?",
+  "@saveTripPageAutoAddCatchesPrompt": {
+    "placeholders": {
+      "numOfCatches": {
+        "type": "int"
+      }
+    }
+  },
+  "saveTripPageAutoAddCatchesPromptSingular": "1 captura se realizó durante este viaje. ¿Agregarla?",
+  "saveTripPageAutoAddCatchesTitle": "Auto-agregar capturas",
   "saveTripPageAutoSetTitle": "Auto-establecer campos",
   "saveTripPageCatchesDesc": "Trofeos registrados en este viaje.",
   "saveTripPageEditTitle": "Editar viaje",

--- a/mobile/lib/pages/save_trip_page.dart
+++ b/mobile/lib/pages/save_trip_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:adair_flutter_lib/l10n/l10n.dart';
 import 'package:adair_flutter_lib/managers/subscription_manager.dart';
 import 'package:adair_flutter_lib/managers/time_manager.dart';
 import 'package:adair_flutter_lib/res/dimen.dart';
@@ -216,12 +217,24 @@ class SaveTripPageState extends State<SaveTripPage> {
   }
 
   Widget _buildAutoPopulateFieldsHeader() {
-    return CheckboxInput(
-      label: Strings.of(context).saveTripPageAutoSetTitle,
-      description: Strings.of(context).saveTripPageAutoSetDescription,
-      value: UserPreferenceManager.get.autoSetTripFields,
-      onChanged: (value) =>
-          UserPreferenceManager.get.setAutoSetTripFields(value),
+    return Column(
+      children: [
+        CheckboxInput(
+          label: Strings.of(context).saveTripPageAutoSetTitle,
+          description: Strings.of(context).saveTripPageAutoSetDescription,
+          value: UserPreferenceManager.get.autoSetTripFields,
+          onChanged: (value) =>
+              UserPreferenceManager.get.setAutoSetTripFields(value),
+        ),
+        CheckboxInput(
+          label: Strings.of(context).saveTripPageAutoAddCatchesTitle,
+          description:
+              Strings.of(context).saveTripPageAutoAddCatchesDescription,
+          value: UserPreferenceManager.get.autoAddCatchesToTrip,
+          onChanged: (value) =>
+              UserPreferenceManager.get.setAutoAddCatchesToTrip(value),
+        ),
+      ],
     );
   }
 
@@ -593,14 +606,27 @@ class SaveTripPageState extends State<SaveTripPage> {
     );
   }
 
-  FutureOr<bool> _save(Map<Id, dynamic> customFieldValueMap) {
+  FutureOr<bool> _save(Map<Id, dynamic> customFieldValueMap) async {
+    var catchIds = Set<Id>.of(_catchesController.value);
+
+    // Auto-add catches that fall within the trip's time period.
+    if (UserPreferenceManager.get.autoAddCatchesToTrip) {
+      var newCatchIds = _findCatchesInTripRange(catchIds);
+      if (newCatchIds.isNotEmpty) {
+        var confirmed = await _showAutoAddCatchesPrompt(newCatchIds.length);
+        if (confirmed) {
+          catchIds.addAll(newCatchIds);
+        }
+      }
+    }
+
     // imageNames is set in _tripManager.addOrUpdate.
     var newTrip = Trip(
       id: _oldTrip?.id ?? randomId(),
       startTimestamp: Int64(_startTimestampController.timestamp),
       endTimestamp: Int64(_endTimestampController.timestamp),
       timeZone: _timeZoneController.value,
-      catchIds: _catchesController.value,
+      catchIds: catchIds,
       bodyOfWaterIds: _bodiesOfWaterController.value,
       catchesPerSpecies: _speciesCatchesController.value,
       catchesPerAngler: _anglerCatchesController.value,
@@ -641,6 +667,51 @@ class SaveTripPageState extends State<SaveTripPage> {
     );
 
     return true;
+  }
+
+  /// Returns catch IDs that fall within the trip's time range but are not
+  /// already included in [existingCatchIds].
+  Set<Id> _findCatchesInTripRange(Set<Id> existingCatchIds) {
+    var startMs = _startTimestampController.timestamp;
+    var endMs = _endTimestampController.timestamp;
+    if (startMs == 0 || endMs == 0 || startMs >= endMs) {
+      return {};
+    }
+
+    return CatchManager.get
+        .list()
+        .where(
+          (cat) =>
+              cat.timestamp.toInt() >= startMs &&
+              cat.timestamp.toInt() <= endMs &&
+              !existingCatchIds.contains(cat.id),
+        )
+        .map((cat) => cat.id)
+        .toSet();
+  }
+
+  Future<bool> _showAutoAddCatchesPrompt(int count) async {
+    var message = count == 1
+        ? Strings.of(context).saveTripPageAutoAddCatchesPromptSingular
+        : Strings.of(context).saveTripPageAutoAddCatchesPrompt(count);
+
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            content: Text(message),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: Text(L10n.get.lib.no),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: Text(L10n.get.lib.yes),
+              ),
+            ],
+          ),
+        ) ??
+        false;
   }
 }
 

--- a/mobile/lib/user_preference_manager.dart
+++ b/mobile/lib/user_preference_manager.dart
@@ -28,6 +28,7 @@ class UserPreferenceManager extends PreferenceManager {
   static const _keyTripFieldIds = "trip_field_ids";
   static const _keyGearFieldIds = "gear_field_ids";
   static const _keyTripAutoSetFields = "trip_auto_set_fields";
+  static const _keyAutoAddCatchesToTrip = "auto_add_catches_to_trip";
   static const _keyTideHeightSystem = "tide_height_system";
   static const _keyCatchLengthSystem = "catch_length_system";
   static const _keyCatchWeightSystem = "catch_weight_system";
@@ -120,6 +121,13 @@ class UserPreferenceManager extends PreferenceManager {
       put(_keyTripAutoSetFields, autoFetch);
 
   bool get autoSetTripFields => preferences[_keyTripAutoSetFields] ?? true;
+
+  // ignore: avoid_positional_boolean_parameters
+  Future<void> setAutoAddCatchesToTrip(bool value) =>
+      put(_keyAutoAddCatchesToTrip, value);
+
+  bool get autoAddCatchesToTrip =>
+      preferences[_keyAutoAddCatchesToTrip] ?? false;
 
   Future<void> setTideHeightSystem(MeasurementSystem? system) =>
       put(_keyTideHeightSystem, system?.value);

--- a/mobile/test/catch_manager_test.dart
+++ b/mobile/test/catch_manager_test.dart
@@ -87,6 +87,10 @@ void main() {
       managers.userPreferenceManager.windSpeedSystem,
     ).thenReturn(MeasurementSystem.metric);
 
+    when(
+      managers.userPreferenceManager.autoAddCatchesToTrip,
+    ).thenReturn(false);
+
     CatchManager.reset();
     catchManager = CatchManager.get;
   });

--- a/mobile/test/catch_manager_test.dart
+++ b/mobile/test/catch_manager_test.dart
@@ -3012,4 +3012,135 @@ void main() {
     expect(catchManager.totalQuantity([id1, id4]), 2);
     expect(catchManager.totalQuantity([id0, id2]), 20);
   });
+
+  test("addOrUpdate auto-adds catch to matching trip", () async {
+    when(
+      managers.userPreferenceManager.autoAddCatchesToTrip,
+    ).thenReturn(true);
+
+    var tripId = randomId();
+    var trip = Trip(
+      id: tripId,
+      startTimestamp: Int64(dateTime(2020, 1, 1).millisecondsSinceEpoch),
+      endTimestamp: Int64(dateTime(2020, 1, 3).millisecondsSinceEpoch),
+    );
+    when(managers.tripManager.list(any)).thenReturn([trip]);
+    when(
+      managers.tripManager.addOrUpdate(any, setImages: anyNamed("setImages")),
+    ).thenAnswer((_) => Future.value(true));
+
+    var cat = Catch(
+      id: randomId(),
+      timestamp: Int64(dateTime(2020, 1, 2).millisecondsSinceEpoch),
+    );
+    await catchManager.addOrUpdate(cat, setImages: false);
+
+    var captured = verify(
+      managers.tripManager.addOrUpdate(
+        captureAny,
+        setImages: anyNamed("setImages"),
+      ),
+    ).captured;
+    var updatedTrip = captured.first as Trip;
+    expect(updatedTrip.catchIds, contains(cat.id));
+  });
+
+  test("addOrUpdate does not auto-add catch without timestamp", () async {
+    when(
+      managers.userPreferenceManager.autoAddCatchesToTrip,
+    ).thenReturn(true);
+
+    var trip = Trip(
+      id: randomId(),
+      startTimestamp: Int64(dateTime(2020, 1, 1).millisecondsSinceEpoch),
+      endTimestamp: Int64(dateTime(2020, 1, 3).millisecondsSinceEpoch),
+    );
+    when(managers.tripManager.list(any)).thenReturn([trip]);
+
+    await catchManager.addOrUpdate(Catch(id: randomId()), setImages: false);
+
+    verifyNever(
+      managers.tripManager.addOrUpdate(
+        any,
+        setImages: anyNamed("setImages"),
+      ),
+    );
+  });
+
+  test("addOrUpdate does not auto-add catch to trip without time range",
+      () async {
+    when(
+      managers.userPreferenceManager.autoAddCatchesToTrip,
+    ).thenReturn(true);
+
+    var trip = Trip(id: randomId());
+    when(managers.tripManager.list(any)).thenReturn([trip]);
+
+    var cat = Catch(
+      id: randomId(),
+      timestamp: Int64(dateTime(2020, 1, 2).millisecondsSinceEpoch),
+    );
+    await catchManager.addOrUpdate(cat, setImages: false);
+
+    verifyNever(
+      managers.tripManager.addOrUpdate(
+        any,
+        setImages: anyNamed("setImages"),
+      ),
+    );
+  });
+
+  test("addOrUpdate does not auto-add catch outside trip range", () async {
+    when(
+      managers.userPreferenceManager.autoAddCatchesToTrip,
+    ).thenReturn(true);
+
+    var trip = Trip(
+      id: randomId(),
+      startTimestamp: Int64(dateTime(2020, 1, 1).millisecondsSinceEpoch),
+      endTimestamp: Int64(dateTime(2020, 1, 3).millisecondsSinceEpoch),
+    );
+    when(managers.tripManager.list(any)).thenReturn([trip]);
+
+    var cat = Catch(
+      id: randomId(),
+      timestamp: Int64(dateTime(2020, 2, 1).millisecondsSinceEpoch),
+    );
+    await catchManager.addOrUpdate(cat, setImages: false);
+
+    verifyNever(
+      managers.tripManager.addOrUpdate(
+        any,
+        setImages: anyNamed("setImages"),
+      ),
+    );
+  });
+
+  test("addOrUpdate does not auto-add catch already in trip", () async {
+    when(
+      managers.userPreferenceManager.autoAddCatchesToTrip,
+    ).thenReturn(true);
+
+    var catId = randomId();
+    var trip = Trip(
+      id: randomId(),
+      startTimestamp: Int64(dateTime(2020, 1, 1).millisecondsSinceEpoch),
+      endTimestamp: Int64(dateTime(2020, 1, 3).millisecondsSinceEpoch),
+      catchIds: [catId],
+    );
+    when(managers.tripManager.list(any)).thenReturn([trip]);
+
+    var cat = Catch(
+      id: catId,
+      timestamp: Int64(dateTime(2020, 1, 2).millisecondsSinceEpoch),
+    );
+    await catchManager.addOrUpdate(cat, setImages: false);
+
+    verifyNever(
+      managers.tripManager.addOrUpdate(
+        any,
+        setImages: anyNamed("setImages"),
+      ),
+    );
+  });
 }

--- a/mobile/test/mocks/mocks.mocks.dart
+++ b/mobile/test/mocks/mocks.mocks.dart
@@ -8901,6 +8901,14 @@ class MockUserPreferenceManager extends _i1.Mock
           as bool);
 
   @override
+  bool get autoAddCatchesToTrip =>
+      (super.noSuchMethod(
+            Invocation.getter(#autoAddCatchesToTrip),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
   _i4.MeasurementSystem get tideHeightSystem =>
       (super.noSuchMethod(
             Invocation.getter(#tideHeightSystem),
@@ -9326,6 +9334,15 @@ class MockUserPreferenceManager extends _i1.Mock
   _i2.Future<void> setAutoSetTripFields(bool? autoFetch) =>
       (super.noSuchMethod(
             Invocation.method(#setAutoSetTripFields, [autoFetch]),
+            returnValue: _i2.Future<void>.value(),
+            returnValueForMissingStub: _i2.Future<void>.value(),
+          )
+          as _i2.Future<void>);
+
+  @override
+  _i2.Future<void> setAutoAddCatchesToTrip(bool? value) =>
+      (super.noSuchMethod(
+            Invocation.method(#setAutoAddCatchesToTrip, [value]),
             returnValue: _i2.Future<void>.value(),
             returnValueForMissingStub: _i2.Future<void>.value(),
           )

--- a/mobile/test/pages/save_trip_page_test.dart
+++ b/mobile/test/pages/save_trip_page_test.dart
@@ -1474,4 +1474,43 @@ void main() {
     expect(trip.startTimestamp.toInt(), now.millisecondsSinceEpoch);
     expect(trip.endTimestamp.toInt(), now.millisecondsSinceEpoch);
   });
+
+  testWidgets("Saving with auto-add prompts and includes matching catches", (
+    tester,
+  ) async {
+    when(managers.userPreferenceManager.autoAddCatchesToTrip).thenReturn(true);
+
+    // catches[0] has timestamp dateTime(2020, 1, 1) which falls within
+    // the trip range. catches[1] and catches[2] are outside the range.
+    var trip = Trip(
+      id: randomId(),
+      startTimestamp: Int64(dateTime(2019, 12, 31).millisecondsSinceEpoch),
+      endTimestamp: Int64(dateTime(2020, 1, 2).millisecondsSinceEpoch),
+      timeZone: defaultTimeZone,
+    );
+
+    await tester.pumpWidget(Testable((_) => SaveTripPage.edit(trip)));
+
+    await tapAndSettle(tester, find.text("SAVE"));
+
+    // Verify the auto-add prompt is shown.
+    expect(
+      find.text("1 catch was made during this trip. Add it?"),
+      findsOneWidget,
+    );
+
+    // Confirm the prompt.
+    await tapAndSettle(tester, find.text("Yes"));
+
+    var result = verify(
+      managers.tripManager.addOrUpdate(
+        captureAny,
+        imageFiles: anyNamed("imageFiles"),
+      ),
+    );
+    result.called(1);
+
+    var savedTrip = result.captured.first as Trip;
+    expect(savedTrip.catchIds, contains(catches[0].id));
+  });
 }

--- a/mobile/test/pages/save_trip_page_test.dart
+++ b/mobile/test/pages/save_trip_page_test.dart
@@ -310,6 +310,7 @@ void main() {
       managers.userPreferenceManager.windSpeedMetricUnit,
     ).thenReturn(Unit.kilometers_per_hour);
     when(managers.userPreferenceManager.autoSetTripFields).thenReturn(true);
+    when(managers.userPreferenceManager.autoAddCatchesToTrip).thenReturn(false);
     when(
       managers.userPreferenceManager.waterDepthSystem,
     ).thenReturn(MeasurementSystem.metric);
@@ -706,9 +707,9 @@ void main() {
     var checkboxes = tester
         .widgetList<PaddedCheckbox>(find.byType(PaddedCheckbox))
         .toList();
-    expect(checkboxes.length, 3); // First checkbox is for auto-set fields.
-    expect(checkboxes[1].checked, isTrue);
+    expect(checkboxes.length, 4); // First two checkboxes are for auto-set/auto-add fields.
     expect(checkboxes[2].checked, isTrue);
+    expect(checkboxes[3].checked, isTrue);
   });
 
   testWidgets("Checking All Day sets time of day to 0", (tester) async {
@@ -716,8 +717,8 @@ void main() {
 
     await tester.pumpWidget(Testable((_) => SaveTripPage.edit(trip)));
 
-    await tapAndSettle(tester, find.byType(PaddedCheckbox).at(1));
     await tapAndSettle(tester, find.byType(PaddedCheckbox).at(2));
+    await tapAndSettle(tester, find.byType(PaddedCheckbox).at(3));
     await tapAndSettle(tester, find.text("SAVE"));
 
     var result = verify(
@@ -1421,8 +1422,8 @@ void main() {
       expect(find.text("Jan 1, 2020"), findsNWidgets(2));
       expect(find.text("3:30 AM"), findsNWidgets(2));
 
-      await tapAndSettle(tester, find.byType(Checkbox).at(1));
       await tapAndSettle(tester, find.byType(Checkbox).at(2));
+      await tapAndSettle(tester, find.byType(Checkbox).at(3));
 
       expect(find.text("12:00 AM"), findsNWidgets(2));
 


### PR DESCRIPTION
When saving a trip, prompts to include existing catches within the date range. When saving a catch, auto-adds it to any in-progress trips. Controlled by a new opt-in "Auto-add Catches" preference on the trip form.

Implements issue #900