### PR TITLE
Fix onboarding menu crash from unguarded Navigator.pop()

### DIFF
--- a/mobile/lib/pages/onboarding/how_to_manage_fields_page.dart
+++ b/mobile/lib/pages/onboarding/how_to_manage_fields_page.dart
@@ -34,10 +34,18 @@ class HowToManageFieldsPageState extends State<HowToManageFieldsPage> {
   void initState() {
     super.initState();
     _menuTimer = Timer.periodic(_menuTimerDuration, (_) {
+      final context = _popupMenuKey.currentContext;
+      if (context == null) {
+        return;
+      }
+
       if (_isMenuShowing) {
-        Navigator.of(_popupMenuKey.currentContext!).pop();
+        var navigator = Navigator.of(context);
+        if (navigator.canPop()) {
+          navigator.pop();
+        }
       } else {
-        _popupMenuKey.currentState!.showButtonMenu();
+        _popupMenuKey.currentState?.showButtonMenu();
       }
       _isMenuShowing = !_isMenuShowing;
     });

--- a/mobile/test/pages/onboarding/how_to_manage_fields_page_test.dart
+++ b/mobile/test/pages/onboarding/how_to_manage_fields_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile/model/gen/anglers_log.pb.dart';
 import 'package:mobile/pages/onboarding/how_to_manage_fields_page.dart';
@@ -63,4 +64,33 @@ void main() {
     await tester.pump(const Duration(milliseconds: 2000));
     expect(find.text("Manage Fields"), findsNWidgets(2));
   });
+
+  testWidgets(
+    "Hide tick does not crash when nested navigator has no routes left",
+    (tester) async {
+      await pumpContext(tester, (_) => const HowToManageFieldsPage());
+
+      // Opens the popup menu; the timer now expects a matching hide tick.
+      await tester.pump(const Duration(milliseconds: 2000));
+      expect(find.text("Manage Fields"), findsNWidgets(2));
+
+      // Drains the embedded page's nested navigator down to zero routes,
+      // reproducing the state Crashlytics events show in the field: by
+      // the time the timer's hide tick runs, there's nothing left for it
+      // to pop.
+      var popupMenuButtonFinder = find.byWidgetPredicate(
+        (widget) => widget is PopupMenuButton,
+      );
+      for (var i = 0; i < 3; i++) {
+        Navigator.of(tester.element(popupMenuButtonFinder.first)).pop();
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+
+      // The timer's hide tick fires against a navigator with no routes
+      // left to pop.
+      await tester.pump(const Duration(milliseconds: 2000));
+
+      expect(tester.takeException(), isNull);
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- `HowToManageFieldsPageState`'s `Timer.periodic` (in the "how to manage fields" onboarding tutorial page) force-unwrapped `_popupMenuKey.currentContext!` and called `Navigator.of(context).pop()` unconditionally every time the timer decided the popup menu should hide.
- `EmbeddedPage` wraps the tutorial's mini "app preview" in its own nested `Navigator` (2 base routes: a back-button placeholder route + the actual content route). The `PopupMenuButton`'s menu route is pushed onto that *same* nested navigator (since `PopupMenuButton.useRootNavigator` defaults to `false`).
- If that nested navigator's route stack gets drained down to zero present routes by the time the timer's next "hide" tick runs, the old code's unconditional `.pop()` throws `Bad state: No element` (Flutter's `NavigatorState.pop()` calls `_history.lastWhere(isPresentPredicate)`, which throws on an empty iterable — see `navigator.dart:5612`). A separate Crashlytics variant of the same issue shows a null-check crash on `_popupMenuKey.currentContext!` when the button's context isn't available at all.

## Why the crash happens

`Navigator.of(_popupMenuKey.currentContext!).pop()` assumed the popup menu's route is always poppable whenever the timer's internal `_isMenuShowing` flag says "showing." But `_isMenuShowing` is a local flag only ever toggled by the timer itself — it doesn't track the *actual* state of the nested navigator's route stack. Once external factors (variability in how the demo's routes settle/animate) leave the nested navigator with nothing left to pop, the unconditional `Navigator.pop()` throws `Bad state: No element`. Separately, `_popupMenuKey.currentContext!` throws its own null-check crash whenever the button isn't currently mounted.

## Reproduction steps for the crash

Derived from the two Crashlytics exception variants on this issue (both blame `how_to_manage_fields_page.dart:38`):
1. Open the onboarding flow and reach the "How to manage fields" tutorial page, which auto-cycles an overflow popup menu open/closed every 2 seconds via a `Timer.periodic`.
2. Something drains the popup's nested `Navigator` (inside `EmbeddedPage`) down to zero present routes before the timer's next scheduled "hide" tick fires.
3. The timer's next tick calls `Navigator.of(context).pop()` unconditionally, throwing `Bad state: No element` (or, in the sibling variant, `_popupMenuKey.currentContext!` is null and throws on the force-unwrap).

The exact device-level trigger for what drains the nested navigator isn't reconstructable from the available sample events, but the crash is fully reproducible in isolation by draining the nested navigator's route stack via direct `Navigator.pop()` calls and then letting the timer's own tick run — see the new regression test.

## Root-cause / fix

Guard both unsafe operations:
- Skip the tick entirely if `_popupMenuKey.currentContext` is `null`.
- Only call `Navigator.pop()` when `Navigator.canPop()` is `true`.
- Use `?.` instead of `!` for `_popupMenuKey.currentState` in the "show" branch for the same reason.

## Crashlytics issue

https://github.com/cohenadair/anglers-log/issues/1113
Crashlytics: https://console.firebase.google.com/v1/appid/project/anglers-log/crashlytics/app/1:1018039459325:android:f4b10d819dbf3934/issues/54045436f273f7077fb6f71409c92dd2

## Test plan

- [x] Added a widget test that reproduces the exact crash: opens the tutorial's popup menu, drains the nested navigator's route stack to zero via direct `Navigator.pop()` calls (matching the framework mechanics that also drive the timer's own pop), then lets the timer's next tick run and asserts no exception is thrown.
- [x] Verified the new test fails against the pre-fix code with the identical stack trace/exception (`Bad state: No element` at `NavigatorState.pop` → `HowToManageFieldsPageState.initState.<fn>:38`) reported in Crashlytics, and passes with the fix.
- [x] `flutter test test/pages/onboarding/how_to_manage_fields_page_test.dart` passes (both the existing and new test).
- [x] `dart format` run on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)