### PR TITLE
Don't show interactive Google Sign-In UI during automatic startup auth

### DIFF
--- a/mobile/lib/backup_restore_manager.dart
+++ b/mobile/lib/backup_restore_manager.dart
@@ -153,7 +153,7 @@ class BackupRestoreManager {
     }
 
     _log.d("Authenticating user for data backup and restore");
-    await _authenticateAndSetupAutoBackup();
+    await _authenticateAndSetupAutoBackup(allowInteractiveSignIn: false);
   }
 
   EntityListener<T> _createEntityListener<T>() {
@@ -164,11 +164,18 @@ class BackupRestoreManager {
     );
   }
 
-  Future<void> _authenticateAndSetupAutoBackup() async {
-    await _authenticateUser();
+  Future<void> _authenticateAndSetupAutoBackup({
+    bool allowInteractiveSignIn = true,
+  }) async {
+    await _authenticateUser(allowInteractiveSignIn: allowInteractiveSignIn);
   }
 
-  Future<void> _authenticateUser() async {
+  /// Authenticates the user with Google Sign-In. [allowInteractiveSignIn]
+  /// must be false when called during app startup, before a
+  /// presentingViewController is available to show sign in UI; interactive
+  /// sign in is only safe once the user has taken an action (i.e. changed
+  /// backup preferences) after startup has finished.
+  Future<void> _authenticateUser({bool allowInteractiveSignIn = true}) async {
     if (_currentUser != null) {
       return;
     }
@@ -178,9 +185,10 @@ class BackupRestoreManager {
     ]);
 
     try {
-      _currentUser =
-          await _googleSignIn?.signInSilently(reAuthenticate: true) ??
-          await _googleSignIn?.signIn();
+      _currentUser = await _googleSignIn?.signInSilently(reAuthenticate: true);
+      if (_currentUser == null && allowInteractiveSignIn) {
+        _currentUser = await _googleSignIn?.signIn();
+      }
       _log.d("Current user: ${_currentUser?.email}");
     } catch (error) {
       if (error is PlatformException && error.details == "access_denied") {

--- a/mobile/test/backup_restore_manager_test.dart
+++ b/mobile/test/backup_restore_manager_test.dart
@@ -243,15 +243,35 @@ void main() {
     verifyNever(managers.googleSignInWrapper.newInstance(any));
   });
 
-  test("UI is shown if silent authentication fails", () async {
+  test("UI is not shown on startup if silent authentication fails", () async {
     when(
       googleSignIn.signInSilently(reAuthenticate: anyNamed("reAuthenticate")),
     ).thenAnswer((_) => Future.value(null));
     when(googleSignIn.signIn()).thenAnswer((_) => Future.value(account));
 
     await backupRestoreManager.initialize();
-    verify(googleSignIn.signIn()).called(1);
+    verifyNever(googleSignIn.signIn());
   });
+
+  test(
+    "UI is shown if silent authentication fails after preferences change",
+    () async {
+      // Use real UserPreferenceManager to test listener.
+      UserPreferenceManager.reset();
+      UserPreferenceManager.get.setDidSetupBackup(false);
+
+      when(
+        googleSignIn.signInSilently(reAuthenticate: anyNamed("reAuthenticate")),
+      ).thenAnswer((_) => Future.value(null));
+      when(googleSignIn.signIn()).thenAnswer((_) => Future.value(account));
+
+      await backupRestoreManager.initialize();
+
+      await UserPreferenceManager.get.setDidSetupBackup(true);
+      await untilCalled(googleSignIn.signIn());
+      verify(googleSignIn.signIn()).called(1);
+    },
+  );
 
   test("Auth fails", () async {
     when(


### PR DESCRIPTION
## Summary

- `BackupRestoreManager.initialize()` runs on every app launch (as part of `AppManager.init()`'s startup sequence, before the UI is fully rendered) and re-authenticates the user for backup if `didSetupBackup` is true.
- `_authenticateUser()`'s implementation was `await signInSilently(reAuthenticate: true) ?? await signIn()` — if the silent, non-interactive re-auth fails (e.g. the cached Google session was revoked or expired), it automatically fell through to the **interactive** `signIn()` flow, which needs to present a native sign-in UI.
- That interactive flow needs a `presentingViewController`, which isn't available yet this early in app startup — causing a fatal `NSInvalidArgumentException: |presentingViewController| must be set.` crash in `FLTGoogleSignInPlugin`.
- Since the crash happens inside the native `signIn()` call itself, the Dart-level catch block (which would otherwise call `UserPreferenceManager.get.setDidSetupBackup(false)` and stop retrying) never runs — the app just crashes. Because `didSetupBackup` stays `true`, this repeats on **every subsequent launch**, trapping affected users in a crash loop until they reinstall. This matches the Crashlytics repetitive signal (~32 events per affected user) and early-session signal (96% within the first second).

## Why the crash happens

The same `_authenticateUser()` method is used for two different triggers:
1. Automatic re-auth at app startup (`initialize()`), where no user gesture has occurred and the view hierarchy isn't ready to present native UI.
2. User-driven re-auth when `didSetupBackup` changes via the preferences stream listener (i.e. the user just enabled backup from settings), where the app is fully running and presenting a sign-in prompt is expected and safe.

The interactive `signIn()` fallback is only safe for case 2, but the code applied it unconditionally to both.

## Fix

Added an `allowInteractiveSignIn` parameter threaded through `_authenticateAndSetupAutoBackup`/`_authenticateUser`, defaulting to `true` (preserves today's behavior for the user-driven path) and passed `false` from `initialize()`'s startup call site. When silent auth fails during startup, the code now falls through to the existing "sign in failed" path (`setDidSetupBackup(false)`) instead of crashing — the same outcome that already occurs today if the interactive flow itself fails or is cancelled.

## Reproduction steps for the crash

Derived from the stack trace and logs (not independently reproduced, since it requires a genuinely-expired/revoked Google session at cold start): a user who previously enabled Google Drive backup has their cached Google session invalidated (token expiry, revoked access, etc.) while the app is closed. On the next app launch, `BackupRestoreManager.initialize()` runs automatically, `signInSilently` fails, and the old code attempted an interactive `signIn()` before any view controller was ready to present it, crashing immediately (96% of events happen within the first second of a session) and on effectively every subsequent launch.

## Crashlytics issue

https://github.com/cohenadair/anglers-log/issues/828 (previously investigated in 2023, referencing [flutter/flutter#101700](https://github.com/flutter/flutter/issues/101700) as an SDK-level limitation with no clear fix — this PR instead removes the app's own incorrect fallback to an interactive flow during unattended startup, which is what's actually triggering the SDK limitation here.)
Crashlytics: https://console.firebase.google.com/v1/appid/project/anglers-log/crashlytics/app/1:1018039459325:ios:b91fa700d0742896244d94/issues/befc3cede6c12e39a276f45f5d2df663

## Test plan

- [x] Updated the existing test "UI is shown if silent authentication fails" (renamed to "UI is not shown on startup if silent authentication fails") — it previously asserted the buggy behavior (`signIn()` called during `initialize()`); now asserts it's never called.
- [x] Added a new test "UI is shown if silent authentication fails after preferences change" verifying the interactive path is still exercised correctly when triggered by a real user-driven preference change (using a real `UserPreferenceManager`, matching the pattern of the existing "User is logged in when preferences changes" test).
- [x] Full `flutter test` run: 2361 passed, 6 skipped (pre-existing/unrelated), 0 failed.
- [x] `dart format` run on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)