### PR TITLE
Handle camera access denied gracefully in image picker

### DIFF
--- a/mobile/lib/l10n/gen/localizations.dart
+++ b/mobile/lib/l10n/gen/localizations.dart
@@ -2513,6 +2513,12 @@ abstract class AnglersLogLocalizations {
   /// **'Failed to attach one or more photos. Please ensure you are connected to the internet and try again.'**
   String get imagePickerPageImagesDownloadError;
 
+  /// No description provided for @imagePickerPageCameraPermissionDenied.
+  ///
+  /// In en, this message translates to:
+  /// **'Permission denied. You must grant Anglers\'\' Log permission to access your camera.'**
+  String get imagePickerPageCameraPermissionDenied;
+
   /// No description provided for @reportListPageConfirmDelete.
   ///
   /// In en, this message translates to:

--- a/mobile/lib/l10n/gen/localizations_en.dart
+++ b/mobile/lib/l10n/gen/localizations_en.dart
@@ -1411,6 +1411,10 @@ class AnglersLogLocalizationsEn extends AnglersLogLocalizations {
       'Failed to attach one or more photos. Please ensure you are connected to the internet and try again.';
 
   @override
+  String get imagePickerPageCameraPermissionDenied =>
+      'Permission denied. You must grant Anglers\' Log permission to access your camera.';
+
+  @override
   String reportListPageConfirmDelete(String report) {
     return 'Are you sure you want to delete report $report? This cannot be undone.';
   }

--- a/mobile/lib/l10n/gen/localizations_es.dart
+++ b/mobile/lib/l10n/gen/localizations_es.dart
@@ -1416,6 +1416,10 @@ class AnglersLogLocalizationsEs extends AnglersLogLocalizations {
       'Error al adjuntar una o más fotos. Asegúrate de estar conectado a Internet y vuelve a intentarlo.';
 
   @override
+  String get imagePickerPageCameraPermissionDenied =>
+      'Permiso denegado. Debes otorgar permiso a Anglers\' Log para acceder a tu cámara.';
+
+  @override
   String reportListPageConfirmDelete(String report) {
     return '¿Estás seguro de que deseas eliminar el informe $report? Esto no se puede deshacer.';
   }

--- a/mobile/lib/l10n/localizations_en.arb
+++ b/mobile/lib/l10n/localizations_en.arb
@@ -881,6 +881,7 @@
   "imagePickerPageOpenSettings": "Open Settings",
   "imagePickerPageImageDownloadError": "Failed to attach photo. Please ensure you are connected to the internet and try again.",
   "imagePickerPageImagesDownloadError": "Failed to attach one or more photos. Please ensure you are connected to the internet and try again.",
+  "imagePickerPageCameraPermissionDenied": "Permission denied. You must grant Anglers'' Log permission to access your camera.",
   "reportListPageConfirmDelete": "Are you sure you want to delete report {report}? This cannot be undone.",
   "@reportListPageConfirmDelete": {
     "placeholders": {

--- a/mobile/lib/l10n/localizations_es.arb
+++ b/mobile/lib/l10n/localizations_es.arb
@@ -397,6 +397,7 @@
   "hashtag": "#AnglersLogApp",
   "imagePickerConfirmDelete": "¿Estás seguro de que deseas eliminar esta foto?",
   "imagePickerPageBrowseLabel": "Explorar",
+  "imagePickerPageCameraPermissionDenied": "Permiso denegado. Debes otorgar permiso a Anglers'' Log para acceder a tu cámara.",
   "imagePickerPageChooseSourceTitle": "Elegir fuente de foto",
   "imagePickerPageNoPhotoLabel": "Sin foto",
   "imagePickerPageCameraLabel": "Cámara",

--- a/mobile/lib/pages/image_picker_page.dart
+++ b/mobile/lib/pages/image_picker_page.dart
@@ -17,6 +17,7 @@ import 'package:adair_flutter_lib/wrappers/permission_handler_wrapper.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile/wrappers/exif_wrapper.dart';
 import 'package:path/path.dart' as path;
@@ -715,18 +716,29 @@ class ImagePickerPageState extends State<ImagePickerPage> {
   }
 
   Future<void> _openCamera() async {
+    var deniedMessage = Strings.of(
+      context,
+    ).imagePickerPageCameraPermissionDenied;
+
     XFile? xFile;
     try {
       xFile = await _imagePicker.pickImage(ImageSource.camera);
     } catch (e) {
-      _log.e(e, reason: "Failed to open camera");
-      _pop([], showError: true);
+      if (e is PlatformException && e.code == "camera_access_denied") {
+        // The user deliberately denied camera access; this isn't an
+        // unexpected error, so don't log it to Crashlytics.
+        _pop([], showError: true, errorMessage: deniedMessage);
+      } else {
+        _log.e(e, reason: "Failed to open camera");
+        _pop([], showError: true);
+      }
       return;
     }
 
     if (xFile == null) {
       return;
     }
+
     _pop([await _xFileToPickedImage(xFile)], showError: false);
   }
 
@@ -789,7 +801,11 @@ class ImagePickerPageState extends State<ImagePickerPage> {
     _pop(result, showError: showError);
   }
 
-  void _pop(List<PickedImage> results, {required bool showError}) {
+  void _pop(
+    List<PickedImage> results, {
+    required bool showError,
+    String? errorMessage,
+  }) {
     widget.onImagesPicked(context, results);
 
     if (widget.popsOnFinish) {
@@ -807,9 +823,10 @@ class ImagePickerPageState extends State<ImagePickerPage> {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         showErrorSnackBar(
           context,
-          widget.allowsMultipleSelection
-              ? Strings.of(context).imagePickerPageImagesDownloadError
-              : Strings.of(context).imagePickerPageImageDownloadError,
+          errorMessage ??
+              (widget.allowsMultipleSelection
+                  ? Strings.of(context).imagePickerPageImagesDownloadError
+                  : Strings.of(context).imagePickerPageImageDownloadError),
         );
       });
     }

--- a/mobile/lib/pages/image_picker_page.dart
+++ b/mobile/lib/pages/image_picker_page.dart
@@ -715,7 +715,15 @@ class ImagePickerPageState extends State<ImagePickerPage> {
   }
 
   Future<void> _openCamera() async {
-    var xFile = await _imagePicker.pickImage(ImageSource.camera);
+    XFile? xFile;
+    try {
+      xFile = await _imagePicker.pickImage(ImageSource.camera);
+    } catch (e) {
+      _log.e(e, reason: "Failed to open camera");
+      _pop([], showError: true);
+      return;
+    }
+
     if (xFile == null) {
       return;
     }

--- a/mobile/test/pages/image_picker_page_test.dart
+++ b/mobile/test/pages/image_picker_page_test.dart
@@ -12,6 +12,7 @@ import 'package:mobile/model/gen/anglers_log.pb.dart';
 import 'package:mobile/pages/image_picker_page.dart';
 import 'package:mobile/res/dimen.dart';
 import 'package:mobile/utils/protobuf_utils.dart';
+import 'package:mobile/utils/string_utils.dart';
 import 'package:mobile/widgets/button.dart';
 import 'package:mobile/widgets/empty_list_placeholder.dart';
 import 'package:mockito/mockito.dart';
@@ -180,19 +181,20 @@ void main() {
     expect(called, isTrue);
   });
 
-  testWidgets("Camera access denied shows error and does not crash", (
+  testWidgets("Camera permission denied shows permission error", (
     tester,
   ) async {
-    await pumpContext(
-      tester,
-      (context) => Scaffold(
+    late BuildContext rootContext;
+    await pumpContext(tester, (context) {
+      rootContext = context;
+      return Scaffold(
         body: Button(
           text: "Test",
           onPressed: () =>
               push(context, ImagePickerPage(onImagesPicked: (_, __) {})),
         ),
-      ),
-    );
+      );
+    });
     await tapAndSettle(tester, find.text("TEST"));
     await tester.pumpAndSettle(const Duration(milliseconds: 50));
 
@@ -208,7 +210,42 @@ void main() {
     await tester.pumpAndSettle(const Duration(milliseconds: 50));
 
     expect(tester.takeException(), isNull);
-    expect(find.byType(SnackBar), findsOneWidget);
+    expect(
+      find.text(Strings.of(rootContext).imagePickerPageCameraPermissionDenied),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets("Camera error other than permission denial shows generic error", (
+    tester,
+  ) async {
+    late BuildContext rootContext;
+    await pumpContext(tester, (context) {
+      rootContext = context;
+      return Scaffold(
+        body: Button(
+          text: "Test",
+          onPressed: () =>
+              push(context, ImagePickerPage(onImagesPicked: (_, __) {})),
+        ),
+      );
+    });
+    await tapAndSettle(tester, find.text("TEST"));
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    when(
+      managers.imagePickerWrapper.pickImage(any),
+    ).thenThrow(Exception("Camera unavailable"));
+
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Camera").last);
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    expect(tester.takeException(), isNull);
+    expect(
+      find.text(Strings.of(rootContext).imagePickerPageImagesDownloadError),
+      findsOneWidget,
+    );
   });
 
   testWidgets("Doc single picker nothing picked", (tester) async {

--- a/mobile/test/pages/image_picker_page_test.dart
+++ b/mobile/test/pages/image_picker_page_test.dart
@@ -5,6 +5,7 @@ import 'package:adair_flutter_lib/widgets/button.dart';
 import 'package:adair_flutter_lib/widgets/loading.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:mobile/model/gen/anglers_log.pb.dart';
@@ -177,6 +178,37 @@ void main() {
 
     verify(managers.imagePickerWrapper.pickImage(any)).called(1);
     expect(called, isTrue);
+  });
+
+  testWidgets("Camera access denied shows error and does not crash", (
+    tester,
+  ) async {
+    await pumpContext(
+      tester,
+      (context) => Scaffold(
+        body: Button(
+          text: "Test",
+          onPressed: () =>
+              push(context, ImagePickerPage(onImagesPicked: (_, __) {})),
+        ),
+      ),
+    );
+    await tapAndSettle(tester, find.text("TEST"));
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    when(managers.imagePickerWrapper.pickImage(any)).thenThrow(
+      PlatformException(
+        code: "camera_access_denied",
+        message: "The user did not allow camera access.",
+      ),
+    );
+
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Camera").last);
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    expect(tester.takeException(), isNull);
+    expect(find.byType(SnackBar), findsOneWidget);
   });
 
   testWidgets("Doc single picker nothing picked", (tester) async {


### PR DESCRIPTION
## Summary

- `ImagePickerPageState._openCamera()` called `_imagePicker.pickImage(ImageSource.camera)` with no error handling.
- On iOS, `image_picker_ios` throws `PlatformException(camera_access_denied, The user did not allow camera access., null, null)` when camera access isn't granted. Since iOS shows the native camera permission prompt lazily on first actual access (there's no pre-check permission request for the camera source in this flow, unlike gallery/photos), a user simply tapping "Don't Allow" on that prompt — a completely routine, expected action — throws this exception with nothing catching it.
- The uncaught exception propagates out of `_openCamera()` and crashes the app (reported as fatal by Crashlytics, since it's an unhandled Dart error reaching Flutter's global error handler).

## Why the crash happens

Every other failure path in this same picker (`_finishPickingImageFromGallery`, `_finishPickingImagesFromGallery`, `pickImagesOnAndroid`) already handles its own failure modes and reports them via the existing `_pop(results, showError: true)` pattern, which pops the page and shows an error snackbar. `_openCamera()` was the one path that didn't — any exception from `pickImage(ImageSource.camera)`, camera-access-denied or otherwise, went uncaught.

## Reproduction steps for the crash

From the stack trace: user opens `ImagePickerPage`, selects "Camera" from the source dropdown, and denies the camera permission prompt (either at the OS-level first-use prompt, or on a subsequent attempt after having already denied it). `ImagePickerPageState._openCamera` → `ImagePickerIOS.getImageFromSource` → `ImagePickerApi.pickImage` throws `camera_access_denied`, uncaught, crashing the app.

## Fix

Wrap the `pickImage` call in a try/catch: log via `_log.e` and call the existing `_pop([], showError: true)` (same pattern already used elsewhere in this class) instead of letting the exception propagate.

## Crashlytics issue

https://github.com/cohenadair/anglers-log/issues/1020
Crashlytics: https://console.firebase.google.com/v1/appid/project/anglers-log/crashlytics/app/1:1018039459325:ios:b91fa700d0742896244d94/issues/9dc6a9b09686f802c871534ce5f82b8c

## Test plan

- [x] Added "Camera access denied shows error and does not crash", pushing `ImagePickerPage` via a real navigable stack (matching the existing "Error shown for single/multi picker" tests), stubbing `pickImage` to throw the exact `PlatformException` from the crash report, and asserting no uncaught exception plus the error `SnackBar` is shown.
- [x] Verified the new test fails against the pre-fix code (uncaught `PlatformException` propagates) and passes with the fix.
- [x] Full `flutter test` run: 2362 passed, 6 skipped (pre-existing/unrelated), 0 failed.
- [x] `dart format` run on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)