### PR TITLE
Fix silently-failing fishing spot selection and swallow Mapbox noise

### DIFF
--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -38,21 +38,7 @@ import 'wrappers/services_wrapper.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
-  await setupFirebase(
-    nonFatalMatcher: (error, stack) {
-      // There seems to be frequent Mapbox-related crashes on lower end devices,
-      // mostly around touch events. Downgrade them to non-fatals so the app
-      // doesn't crash, but we're still notified in Firebase. The result for
-      // end users will be simply losing a touch event for which they can try
-      // again.
-      //
-      // Related issues:
-      //  - https://github.com/mapbox/mapbox-maps-flutter/issues/887
-      //  - https://github.com/mapbox/mapbox-gestures-android/issues/99
-      return error is PlatformException &&
-          (error.stacktrace?.contains("com.mapbox") ?? false);
-    },
-  );
+  await setupFirebase(ignoreMatcher: isIgnorableMapboxError);
 
   // Restrict orientation to portrait for devices with a small width. A width
   // of 740 is less than the smallest iPad, and most Android tablets.
@@ -67,6 +53,21 @@ void main() async {
   }
 
   runApp(const AnglersLog());
+}
+
+/// There seems to be frequent Mapbox-related crashes on lower end devices,
+/// mostly around touch events. These are swallowed entirely (not recorded
+/// to Crashlytics) so the app doesn't crash and Crashlytics isn't spammed
+/// with a non-fatal we can't act on. The result for end users will be
+/// simply losing a touch event for which they can try again.
+///
+/// Related issues:
+///  - https://github.com/mapbox/mapbox-maps-flutter/issues/887
+///  - https://github.com/mapbox/mapbox-gestures-android/issues/99
+@visibleForTesting
+bool isIgnorableMapboxError(Object error, StackTrace? stack) {
+  return error is PlatformException &&
+      (error.stacktrace?.contains("com.mapbox") ?? false);
 }
 
 class AnglersLog extends StatefulWidget {

--- a/mobile/lib/widgets/fishing_spot_map.dart
+++ b/mobile/lib/widgets/fishing_spot_map.dart
@@ -851,6 +851,20 @@ class FishingSpotMapState extends State<FishingSpotMap> {
       );
 
       if (newActiveSymbol == null) {
+        // The map may not have finished its initial symbol sync yet (for
+        // example, a fishing spot picked from search immediately after the
+        // map page opens, before _setupMap's _updateSymbols call
+        // completes). Add the missing symbol now instead of leaving the
+        // selection stuck with no visible pin.
+        await _mapController?.addSymbol(
+          Symbols.fromFishingSpot(fishingSpot, isActive: true),
+        );
+        newActiveSymbol = _mapController?.symbols.firstWhereOrNull(
+          (s) => fishingSpot.id == s.fishingSpot?.id,
+        );
+      }
+
+      if (newActiveSymbol == null) {
         _log.e("Couldn't find symbol associated with fishing spot");
       } else {
         // Update map.

--- a/mobile/lib/widgets/fishing_spot_map.dart
+++ b/mobile/lib/widgets/fishing_spot_map.dart
@@ -635,6 +635,12 @@ class FishingSpotMapState extends State<FishingSpotMap> {
     return _selectFishingSpot(symbol.fishingSpot, animateMapMovement: true);
   }
 
+  Symbol? _findSymbol(FishingSpot fishingSpot) {
+    return _mapController?.symbols.firstWhereOrNull(
+      (s) => fishingSpot.id == s.fishingSpot?.id,
+    );
+  }
+
   Future<void> _updateSymbols({required FishingSpot? selectedFishingSpot}) {
     var future = _syncSymbols(selectedFishingSpot: selectedFishingSpot);
     _symbolSyncFuture = future;
@@ -861,9 +867,7 @@ class FishingSpotMapState extends State<FishingSpotMap> {
       }
     } else {
       // Find the symbol associated with the given fishing spot.
-      newActiveSymbol = _mapController?.symbols.firstWhereOrNull(
-        (s) => fishingSpot.id == s.fishingSpot?.id,
-      );
+      newActiveSymbol = _findSymbol(fishingSpot);
 
       if (newActiveSymbol == null) {
         // The map may not have finished its initial symbol sync yet (for
@@ -876,9 +880,7 @@ class FishingSpotMapState extends State<FishingSpotMap> {
         var syncFuture = _symbolSyncFuture;
         if (syncFuture != null) {
           await syncFuture;
-          newActiveSymbol = _mapController?.symbols.firstWhereOrNull(
-            (s) => fishingSpot.id == s.fishingSpot?.id,
-          );
+          newActiveSymbol = _findSymbol(fishingSpot);
         }
       }
 
@@ -889,9 +891,7 @@ class FishingSpotMapState extends State<FishingSpotMap> {
         await _mapController?.addSymbol(
           Symbols.fromFishingSpot(fishingSpot, isActive: true),
         );
-        newActiveSymbol = _mapController?.symbols.firstWhereOrNull(
-          (s) => fishingSpot.id == s.fishingSpot?.id,
-        );
+        newActiveSymbol = _findSymbol(fishingSpot);
       }
 
       if (newActiveSymbol == null) {

--- a/mobile/lib/widgets/fishing_spot_map.dart
+++ b/mobile/lib/widgets/fishing_spot_map.dart
@@ -117,6 +117,11 @@ class FishingSpotMapState extends State<FishingSpotMap> {
   Symbol? _activeSymbol;
   SymbolTrail? _activeTrail;
 
+  // Tracks an in-flight _updateSymbols call, if any, so a concurrent
+  // on-demand symbol add (see _selectFishingSpot) can wait for it instead of
+  // racing it and adding a duplicate symbol for the same fishing spot.
+  Future<void>? _symbolSyncFuture;
+
   bool _myLocationEnabled = true;
   bool _didAddFishingSpot = false;
 
@@ -630,9 +635,19 @@ class FishingSpotMapState extends State<FishingSpotMap> {
     return _selectFishingSpot(symbol.fishingSpot, animateMapMovement: true);
   }
 
-  Future<void> _updateSymbols({
-    required FishingSpot? selectedFishingSpot,
-  }) async {
+  Future<void> _updateSymbols({required FishingSpot? selectedFishingSpot}) {
+    var future = _syncSymbols(selectedFishingSpot: selectedFishingSpot);
+    _symbolSyncFuture = future;
+    return future.whenComplete(() {
+      // Only clear if this is still the most recent sync; an overlapping
+      // call may have started (and not yet finished) since this one began.
+      if (identical(_symbolSyncFuture, future)) {
+        _symbolSyncFuture = null;
+      }
+    });
+  }
+
+  Future<void> _syncSymbols({required FishingSpot? selectedFishingSpot}) async {
     var fishingSpotSymbols = _mapController?.fishingSpotSymbols ?? <Symbol>{};
 
     // Update and remove symbols, syncing them with FishingSpotManager.
@@ -854,8 +869,23 @@ class FishingSpotMapState extends State<FishingSpotMap> {
         // The map may not have finished its initial symbol sync yet (for
         // example, a fishing spot picked from search immediately after the
         // map page opens, before _setupMap's _updateSymbols call
-        // completes). Add the missing symbol now instead of leaving the
-        // selection stuck with no visible pin.
+        // completes). Wait for that sync rather than adding the symbol
+        // ourselves here, since it's already about to add one for every
+        // spot, including this one — adding it here too would race it and
+        // leave two symbols for the same fishing spot.
+        var syncFuture = _symbolSyncFuture;
+        if (syncFuture != null) {
+          await syncFuture;
+          newActiveSymbol = _mapController?.symbols.firstWhereOrNull(
+            (s) => fishingSpot.id == s.fishingSpot?.id,
+          );
+        }
+      }
+
+      if (newActiveSymbol == null) {
+        // Still missing after waiting for any in-flight sync (or there was
+        // none running) — add it directly instead of leaving the selection
+        // stuck with no visible pin.
         await _mapController?.addSymbol(
           Symbols.fromFishingSpot(fishingSpot, isActive: true),
         );

--- a/mobile/test/main_test.dart
+++ b/mobile/test/main_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:adair_flutter_lib/pages/landing_page.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile/main.dart';
 import 'package:mobile/model/gen/anglers_log.pb.dart';
@@ -138,6 +139,49 @@ void main() {
     when(channel.invokeMethod(any)).thenAnswer((_) => Future.value(null));
     when(managers.servicesWrapper.methodChannel(any)).thenReturn(channel);
   });
+
+  test(
+    "isIgnorableMapboxError returns false for a non-PlatformException error",
+    () {
+      expect(isIgnorableMapboxError(Exception("test"), null), isFalse);
+    },
+  );
+
+  test("isIgnorableMapboxError returns false when stacktrace is null", () {
+    expect(
+      isIgnorableMapboxError(PlatformException(code: "test"), null),
+      isFalse,
+    );
+  });
+
+  test(
+    "isIgnorableMapboxError returns false when stacktrace doesn't mention Mapbox",
+    () {
+      expect(
+        isIgnorableMapboxError(
+          PlatformException(code: "test", stacktrace: "at com.example.Foo"),
+          null,
+        ),
+        isFalse,
+      );
+    },
+  );
+
+  test(
+    "isIgnorableMapboxError returns true when stacktrace mentions Mapbox",
+    () {
+      expect(
+        isIgnorableMapboxError(
+          PlatformException(
+            code: "test",
+            stacktrace: "at com.mapbox.maps.MapView.onTouchEvent",
+          ),
+          null,
+        ),
+        isTrue,
+      );
+    },
+  );
 
   testWidgets("LandingPage is shown until app initializes", (tester) async {
     // Stub an initialization method taking some time.

--- a/mobile/test/widget/fishing_spot_map_test.dart
+++ b/mobile/test/widget/fishing_spot_map_test.dart
@@ -961,6 +961,74 @@ void main() {
     expect((result.captured.first as PointAnnotation).iconImage, "active-pin");
   });
 
+  testWidgets(
+    "Selecting a spot while initial sync is in-flight doesn't duplicate "
+    "its symbol",
+    (tester) async {
+      var fishingSpot1 = FishingSpot(
+        id: randomId(),
+        name: "Spot 1",
+        lat: 1,
+        lng: 2,
+      );
+      var fishingSpot2 = FishingSpot(
+        id: randomId(),
+        name: "Spot 2",
+        lat: 3,
+        lng: 4,
+      );
+      when(
+        managers.fishingSpotManager.list(),
+      ).thenReturn([fishingSpot1, fishingSpot2]);
+      when(
+        managers.fishingSpotManager.filteredList(any, any),
+      ).thenReturn([fishingSpot1, fishingSpot2]);
+
+      // Gate the initial sync's batch add so it stays in-flight while a spot
+      // is selected via search.
+      var initialSyncGate = Completer<void>();
+      when(
+        mapController.map.pointAnnotationManager.createMulti(any),
+      ).thenAnswer((invocation) async {
+        await initialSyncGate.future;
+        var options =
+            invocation.positionalArguments[0] as List<PointAnnotationOptions>;
+        return options
+            .map(
+              (o) => PointAnnotation(id: randomId().uuid, geometry: o.geometry),
+            )
+            .toList();
+      });
+
+      await pumpMapWrapper(tester, FishingSpotMap());
+
+      // Initial sync is stuck awaiting initialSyncGate; no symbols exist yet.
+      expect(mapController.value.symbols, isEmpty);
+
+      await tapAndSettle(tester, find.byType(OurSearchBar));
+      await tapAndSettle(tester, find.text("Spot 1"));
+
+      // Selecting Spot 1 finds no symbol yet, and waits for the in-flight
+      // sync instead of adding one itself.
+      expect(mapController.value.symbols, isEmpty);
+
+      // Let the initial sync's batch add resume and finish.
+      initialSyncGate.complete();
+      await tester.pumpAndSettle();
+
+      // Exactly one symbol per fishing spot; the selection didn't add a
+      // duplicate for Spot 1 once the sync it waited on completed.
+      expect(mapController.value.symbols.length, 2);
+      expect(
+        mapController.value.symbols
+            .map((s) => s.fishingSpot!.id)
+            .toSet()
+            .length,
+        2,
+      );
+    },
+  );
+
   testWidgets("Selecting spot activates symbol", (tester) async {
     var fishingSpot1 = FishingSpot(
       id: randomId(),

--- a/mobile/test/widget/fishing_spot_map_test.dart
+++ b/mobile/test/widget/fishing_spot_map_test.dart
@@ -921,7 +921,9 @@ void main() {
     verify(mapController.map.pointAnnotationManager.update(any)).called(2);
   });
 
-  testWidgets("Selecting spot that does not exist is a no-op", (tester) async {
+  testWidgets("Selecting spot with a missing symbol re-adds it", (
+    tester,
+  ) async {
     var fishingSpot1 = FishingSpot(
       id: randomId(),
       name: "Spot 1",
@@ -945,9 +947,18 @@ void main() {
     await tapAndSettle(tester, find.byType(OurSearchBar));
 
     await mapController.value.clearSymbols();
+    expect(mapController.value.symbols, isEmpty);
+
     await tapAndSettle(tester, find.text("Spot 1"));
 
-    verifyNever(mapController.map.pointAnnotationManager.update(any));
+    // The missing symbol is re-added and selected, rather than the
+    // selection silently failing.
+    expect(mapController.value.symbols.length, 1);
+    final result = verify(
+      mapController.map.pointAnnotationManager.update(captureAny),
+    );
+    result.called(1);
+    expect((result.captured.first as PointAnnotation).iconImage, "active-pin");
   });
 
   testWidgets("Selecting spot activates symbol", (tester) async {


### PR DESCRIPTION
## Summary

Two independent Crashlytics fixes bundled together since they're both
small and touch related setup code:

### 1. Fishing spot selection silently failing (duplicate non-fatal)

Crashlytics issues [f13953ec17041a969cd1d39bad26b7ac](https://console.firebase.google.com/v1/appid/project/anglers-log/crashlytics/app/1:1018039459325:android:f4b10d819dbf3934/issues/f13953ec17041a969cd1d39bad26b7ac) (Android) and
[2d42509567320134aecbd6708ad5fa8b](https://console.firebase.google.com/v1/appid/project/anglers-log/crashlytics/app/1:1018039459325:ios:b91fa700d0742896244d94/issues/2d42509567320134aecbd6708ad5fa8b) (iOS) are the same underlying bug
surfacing on both platforms — both blame `FishingSpotMapState._selectFishingSpot`
at `mobile/lib/widgets/fishing_spot_map.dart:854`, logging
`"Couldn't find symbol associated with fishing spot"`.

**Why it happens:** `_selectFishingSpot` looks up the map symbol for a
given `FishingSpot` by scanning `_mapController.symbols`. Symbols are
added asynchronously during `_setupMap()` → `_updateSymbols()`, which
runs once when the native map view finishes initializing
(`onMapCreated`). The search bar, however, is interactive immediately —
if a user searches for and picks a fishing spot
(`FishingSpotListPage.onPicked` → `_selectFishingSpot(fishingSpot)`)
before that initial symbol sync finishes, the lookup fails: the spot is
a valid entity, it just doesn't have a map symbol yet. Previously this
just logged a non-fatal and gave up — the fishing spot picker's callback
returned normally, but `_activeSymbol` never got set, so the user's pick
silently did nothing (no pin, no selection).

**Fix:** when the lookup fails, add the missing symbol on demand
(mirroring what `_updateSymbols` does during its normal sync) and retry
the lookup, instead of giving up. This is a genuine race, not a
misuse — the search picker doesn't limit itself to spots already
rendered on the map, so it's fixed at the point where the assumption
breaks, rather than downgrading the log.

Reproduction: open the fishing spot map, immediately search for and pick
a spot before the map has finished its initial symbol sync (more likely
with a large spot collection or a slower device — matches the "lower end
devices" pattern already noted for the Mapbox issue below).

### 2. Mapbox touch-event crash noise (no longer logged)

Crashlytics issue [7097e829b0e22f83f097650288fd81bc](https://console.firebase.google.com/v1/appid/project/anglers-log/crashlytics/app/1:1018039459325:android:f4b10d819dbf3934/issues/7097e829b0e22f83f097650288fd81bc)'s full stack
trace resolves entirely inside Mapbox's obfuscated Android SDK
(`com.mapbox.maps.*`), reached via Flutter's own
`AndroidViewController.dispatchPointerEvent` → `sendMotionEvent` →
`StandardMethodCodec.decodeEnvelope` — no app code or
adair-flutter-lib code anywhere in the chain. `main.dart` already had a
`nonFatalMatcher` that recognized this exact pattern (`PlatformException`
whose stack trace contains `"com.mapbox"`), citing two known, still-open
upstream issues, and downgraded it from fatal to non-fatal so it
wouldn't crash the app. There's no app-side fix available, so this PR
swaps that over to the new `ignoreMatcher` from
[cohenadair/adair-flutter-lib#7](https://github.com/cohenadair/adair-flutter-lib/pull/7),
which fully suppresses recording instead of just downgrading it — same
crash prevention, no more Crashlytics noise for something we can't act
on.

The matcher was also pulled out of the inline closure into a top-level
`isIgnorableMapboxError` function so it's actually unit-testable (it had
zero test coverage before, being buried inside `main()`).

**Depends on [cohenadair/adair-flutter-lib#7](https://github.com/cohenadair/adair-flutter-lib/pull/7) merging first** —
`adair_flutter_lib` is a local path dependency, so `ignoreMatcher` won't
exist until that PR lands.

## Test plan

- [x] `flutter test test/widget/fishing_spot_map_test.dart` — updated
      "Selecting spot with a missing symbol re-adds it" (previously
      "...is a no-op") to assert the symbol is added and selected rather
      than the selection being dropped. Verified this test fails with the
      exact same log line as the Crashlytics report
      (`E/AL-FishingSpotMap: Couldn't find symbol associated with fishing
      spot`) when the fix is reverted, and passes with it applied.
- [x] `flutter test test/main_test.dart` — 4 new tests covering every
      branch of `isIgnorableMapboxError` (non-`PlatformException`, null
      stacktrace, non-matching stacktrace, matching stacktrace).
- [x] `dart format` — clean.