### PR TITLE
Fix file_picker multiple_request crash in ImagePickerPage

### DIFF
--- a/mobile/lib/pages/image_picker_page.dart
+++ b/mobile/lib/pages/image_picker_page.dart
@@ -762,6 +762,10 @@ class ImagePickerPageState extends State<ImagePickerPage> {
       _isPickingFile = false;
     }
 
+    if (!mounted) {
+      return;
+    }
+
     // User cancelled picker.
     if (pickerResult == null) {
       return;

--- a/mobile/lib/pages/image_picker_page.dart
+++ b/mobile/lib/pages/image_picker_page.dart
@@ -313,6 +313,7 @@ class ImagePickerPageState extends State<ImagePickerPage> {
 
   bool _isLoadingPage = false;
   bool _isLoadingGalleryImages = false;
+  bool _isPickingFile = false;
 
   /// Cache thumbnail futures so they're not recreated each time the widget
   /// tree is rebuilt.
@@ -743,10 +744,23 @@ class ImagePickerPageState extends State<ImagePickerPage> {
   }
 
   void _openFilePicker() async {
-    var pickerResult = await _filePicker.pickFiles(
-      type: FileType.image,
-      allowMultiple: widget.allowsMultipleSelection,
-    );
+    if (_isPickingFile) {
+      return;
+    }
+    _isPickingFile = true;
+
+    FilePickerResult? pickerResult;
+    try {
+      pickerResult = await _filePicker.pickFiles(
+        type: FileType.image,
+        allowMultiple: widget.allowsMultipleSelection,
+      );
+    } catch (e) {
+      _log.e(e, reason: "Failed to open file picker");
+      return;
+    } finally {
+      _isPickingFile = false;
+    }
 
     // User cancelled picker.
     if (pickerResult == null) {

--- a/mobile/test/pages/image_picker_page_test.dart
+++ b/mobile/test/pages/image_picker_page_test.dart
@@ -402,6 +402,51 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets("File picker result after page is disposed does not crash", (
+    tester,
+  ) async {
+    var completer = Completer<FilePickerResult?>();
+    when(
+      managers.lib.filePickerWrapper.pickFiles(
+        type: anyNamed("type"),
+        allowMultiple: anyNamed("allowMultiple"),
+      ),
+    ).thenAnswer((_) => completer.future);
+
+    await pumpContext(
+      tester,
+      (context) => Button(
+        text: "Test",
+        onPressed: () =>
+            push(context, ImagePickerPage(onImagesPicked: (_, __) {})),
+      ),
+    );
+    await tapAndSettle(tester, find.text("TEST"));
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Browse").last);
+
+    // The back button pops the page (via _finishPickingImagesFromGallery ->
+    // _pop) while the file picker request above is still pending.
+    await tapAndSettle(tester, find.byType(BackButton));
+    expect(find.byType(ImagePickerPage), findsNothing);
+
+    // Resolve the pending pick after the page has already been disposed.
+    completer.complete(
+      FilePickerResult([
+        PlatformFile(
+          name: "android_logo.png",
+          size: 100,
+          path: "test/resources/android_logo.png",
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets("No done button for single picker", (tester) async {
     await tester.pumpWidget(
       Testable((_) => ImagePickerPage.single(onImagePicked: (_, __) {})),

--- a/mobile/test/pages/image_picker_page_test.dart
+++ b/mobile/test/pages/image_picker_page_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:adair_flutter_lib/utils/page.dart';
@@ -338,6 +339,67 @@ void main() {
 
     expect(find.text("Must select image files."), findsNothing);
     expect(called, isTrue);
+  });
+
+  testWidgets("File picker multiple_request error does not crash", (
+    tester,
+  ) async {
+    var called = false;
+    when(
+      managers.lib.filePickerWrapper.pickFiles(
+        type: anyNamed("type"),
+        allowMultiple: anyNamed("allowMultiple"),
+      ),
+    ).thenThrow(
+      PlatformException(
+        code: "multiple_request",
+        message: "Cancelled by a second request",
+      ),
+    );
+
+    await tester.pumpWidget(
+      Testable(
+        (_) => ImagePickerPage(onImagesPicked: (_, __) => called = true),
+      ),
+    );
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Browse").last);
+
+    expect(tester.takeException(), isNull);
+    expect(called, isFalse);
+  });
+
+  testWidgets("Second file picker request while one in progress is ignored", (
+    tester,
+  ) async {
+    var pickFilesCallCount = 0;
+    var completer = Completer<FilePickerResult?>();
+    when(
+      managers.lib.filePickerWrapper.pickFiles(
+        type: anyNamed("type"),
+        allowMultiple: anyNamed("allowMultiple"),
+      ),
+    ).thenAnswer((_) {
+      pickFilesCallCount++;
+      return completer.future;
+    });
+
+    await tester.pumpWidget(
+      Testable((_) => ImagePickerPage(onImagesPicked: (_, __) {})),
+    );
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Browse").last);
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Browse").last);
+
+    expect(pickFilesCallCount, 1);
+
+    completer.complete(null);
+    await tester.pumpAndSettle();
   });
 
   testWidgets("No done button for single picker", (tester) async {


### PR DESCRIPTION
## Summary
- iOS-only fatal crash: `FilePickerIO._getPath` throws `PlatformException(multiple_request, Cancelled by a second request, null, null)` when `_openFilePicker` in `ImagePickerPage` is invoked a second time before a prior in-flight call resolves. This is documented iOS-side behavior in `file_picker` (see [miguelpruivo/flutter_file_picker#219](https://github.com/miguelpruivo/flutter_file_picker/issues/219)), not something a package upgrade fixes.
- `_openFilePicker` was `async void` with no re-entrancy guard and no error handling, so the exception went unhandled and crashed the app.
- Adds an `_isPickingFile` guard so a second "Browse" selection while a pick is already in flight is ignored, plus a `try`/`catch` around the `pickFiles()` call as a safety net (mirrors the existing `_openCamera` error-handling pattern in the same file).

## Why the crash happens
`_buildSourceDropdown`'s `onChanged` calls `_openFilePicker()` whenever the "Browse" item is selected. Because selecting "Browse" never updates `_currentSource`, the dropdown continues to display "Gallery", so the user can select "Browse" again immediately — re-invoking `_openFilePicker()` while the previous `_filePicker.pickFiles()` call is still awaiting its result. iOS's document picker cancels the first request when a second one comes in, and the underlying platform channel surfaces that cancellation as a `PlatformException` on the first call's `Future`. With no guard and no `try`/`catch`, that exception propagated out of the fire-and-forget `async void` method and was reported as a fatal crash.

## Reproduction steps
1. On iOS, open `ImagePickerPage` and select "Browse" from the source dropdown to open the system document/photo picker.
2. Before completing or cancelling that pick, reopen the dropdown and select "Browse" again.
3. The first `pickFiles()` call rejects with `PlatformException(multiple_request, ...)`, which was previously unhandled and crashed the app.

(Derived from the stack trace and breadcrumbs on the sample event — breadcrumbs show several rapid `PHPickerViewController`/`FlutterViewController` transitions in the seconds before the crash, consistent with the picker being reopened before a prior pick completed.)

## Crashlytics issue
863de24eb8ac5213c3eb2e938c3220a7

## Third-party crash details
- Package: `file_picker` (via `adair_flutter_lib`'s `FilePickerWrapper`)
- Current version: `10.3.10` (constraint `^10.3.10`), already the latest resolvable version — no changelog entry addresses this, since it's expected iOS picker behavior when invoked concurrently, not a bug.
- Fix is a defensive guard in the app-code call site rather than a package change.

## Test plan
- Added `File picker multiple_request error does not crash`: stubs `pickFiles()` to throw the exact `PlatformException` from the Crashlytics report, confirms `tester.takeException()` is null and the picked-images callback is not invoked.
- Added `Second file picker request while one in progress is ignored`: stubs `pickFiles()` with a `Completer` and selects "Browse" twice before resolving, confirms the wrapper is only invoked once.
- Verified both new tests fail with the original crash signature when the fix is reverted, and pass with it applied.
- Ran the full `image_picker_page_test.dart` suite (58 tests) — all passing.