### PR TITLE
Fix null-check crash in ImagePickerPage after disposal during file pick

### DIFF
--- a/mobile/lib/pages/image_picker_page.dart
+++ b/mobile/lib/pages/image_picker_page.dart
@@ -762,6 +762,10 @@ class ImagePickerPageState extends State<ImagePickerPage> {
       _isPickingFile = false;
     }
 
+    if (!mounted) {
+      return;
+    }
+
     // User cancelled picker.
     if (pickerResult == null) {
       return;

--- a/mobile/test/pages/image_picker_page_test.dart
+++ b/mobile/test/pages/image_picker_page_test.dart
@@ -402,6 +402,51 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets("File picker result after page is disposed does not crash", (
+    tester,
+  ) async {
+    var completer = Completer<FilePickerResult?>();
+    when(
+      managers.lib.filePickerWrapper.pickFiles(
+        type: anyNamed("type"),
+        allowMultiple: anyNamed("allowMultiple"),
+      ),
+    ).thenAnswer((_) => completer.future);
+
+    await pumpContext(
+      tester,
+      (context) => Button(
+        text: "Test",
+        onPressed: () =>
+            push(context, ImagePickerPage(onImagesPicked: (_, __) {})),
+      ),
+    );
+    await tapAndSettle(tester, find.text("TEST"));
+    await tester.pumpAndSettle(const Duration(milliseconds: 50));
+
+    await tapAndSettle(tester, find.text("Gallery"));
+    await tapAndSettle(tester, find.text("Browse").last);
+
+    // The back button pops the page (via _finishPickingImagesFromGallery ->
+    // _pop) while the file picker request above is still pending.
+    await tapAndSettle(tester, find.byType(BackButton));
+    expect(find.byType(ImagePickerPage), findsNothing);
+
+    // Resolve the pending pick after the page has already been disposed.
+    completer.complete(
+      FilePickerResult([
+        PlatformFile(
+          name: "android_logo.png",
+          size: 100,
+          path: "test/resources/android_logo.png",
+        ),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets("No done button for single picker", (tester) async {
     await tester.pumpWidget(
       Testable((_) => ImagePickerPage.single(onImagePicked: (_, __) {})),


### PR DESCRIPTION
## Summary
- iOS-only fatal crash: `Null check operator used on a null value` at `ImagePickerPageState._exifFromFile`, blaming `State.context`. This happens when `_openFilePicker`'s pending `pickFiles()` call resolves *after* the page has already been disposed (e.g. the user pressed back before the picker returned), and the code goes on to use `context` via `ExifWrapper.of(context)` on a defunct `State`.
- Adds a `mounted` check immediately after the `pickFiles()` await resolves, before any further processing that touches `context`.

## Stacking note
This PR is based on #1138 (`crashlytics-863de24e`), since both fixes touch the exact same `_openFilePicker` method. It should be retargeted to `master` (or rebased) once #1138 merges.

## Why the crash happens
`_openFilePicker` awaits `_filePicker.pickFiles()`. While that's pending, the user can still press the back button — `WillPopScope.onWillPop` calls `_finishPickingImagesFromGallery()`, which (for a picker with no gallery selection) synchronously calls `_pop([], showError: false)`, and `_pop` calls `Navigator.pop(context)`, disposing `ImagePickerPageState`. When the earlier `pickFiles()` future then resolves, `_openFilePicker` continues running (Dart futures aren't cancelled on widget disposal) and calls `_xFilesToPickedImages` → `_xFileToPickedImage` → `_exifFromFile`, which reads `ExifWrapper.of(context)`. `State.context` null-checks its internal `_element`, which Flutter clears on unmount, so this throws instead of the expected `context` value — this is the "Null check operator used on a null value" from the report.

## Reproduction steps
1. On iOS, open `ImagePickerPage` and select "Browse" to start a file pick (`_filePicker.pickFiles()` begins awaiting the system picker).
2. Before the picker returns, press the back button. The page pops (via `_finishPickingImagesFromGallery` → `_pop`).
3. The in-flight file pick later resolves with a result; `_openFilePicker` continues running against the now-disposed page state and crashes touching `context`.

(Derived from the stack trace: `State.context` → `_exifFromFile` → `_xFileToPickedImage` → `Future.wait` → `_xFilesToPickedImages` → `_openFilePicker`. Breadcrumbs on the sample event show repeated `PHPickerViewController`/`FlutterViewController` transitions in the seconds before the crash, consistent with the picker being reopened/backed-out-of before a prior pick resolved.)

## Crashlytics issue
eda5545e76530e9075a858bd143fa73c

## Test plan
- Added `File picker result after page is disposed does not crash`: stubs `pickFiles()` with a `Completer`, pops the page via the back button while the pick is still pending, then resolves the pick and confirms `tester.takeException()` is null.
- Verified the new test fails with the exact same `State.context` null-check exception/stack signature as the Crashlytics report when the `mounted` check is reverted, and passes with it applied.
- Ran the full `image_picker_page_test.dart` suite (59 tests) — all passing.