### PR TITLE
Fix crash updating map attribution margin after dispose

### DIFF
--- a/mobile/lib/entity_manager.dart
+++ b/mobile/lib/entity_manager.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:adair_flutter_lib/utils/log.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:flutter/material.dart';
 import 'package:protobuf/protobuf.dart';
 import 'package:quiver/strings.dart';
@@ -472,14 +471,15 @@ class EntityListenerBuilderState extends State<EntityListenerBuilder> {
   }
 
   void _notify(VoidCallback? callback) {
-    // safeUseContext is required here in case listeners do some asynchronous
-    // work.
-    safeUseContext(this, () {
-      if (widget.changesUpdatesState) {
-        setState(() => callback?.call());
-      } else {
-        callback?.call();
-      }
-    });
+    // Manager listeners may fire asynchronously after this widget has been
+    // disposed.
+    if (!mounted) {
+      return;
+    }
+    if (widget.changesUpdatesState) {
+      setState(() => callback?.call());
+    } else {
+      callback?.call();
+    }
   }
 }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -9,7 +9,6 @@ import 'package:adair_flutter_lib/res/theme.dart';
 import 'package:adair_flutter_lib/utils/firebase_setup.dart';
 import 'package:adair_flutter_lib/utils/log.dart';
 import 'package:adair_flutter_lib/utils/root.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:adair_flutter_lib/wrappers/crashlytics_wrapper.dart';
 import 'package:adair_flutter_lib/wrappers/package_info_wrapper.dart';
 import 'package:flutter/material.dart';
@@ -109,8 +108,11 @@ class AnglersLogState extends State<AnglersLog> {
 
     _userPreferenceSub = UserPreferenceManager.get.stream.listen((event) {
       if (event == UserPreferenceManager.keyThemeMode) {
+        if (!mounted) {
+          return;
+        }
         setState(() {});
-        safeUseContext(this, () => context.rebuildAllChildren());
+        context.rebuildAllChildren();
       }
     });
   }

--- a/mobile/lib/main.dart
+++ b/mobile/lib/main.dart
@@ -107,10 +107,10 @@ class AnglersLogState extends State<AnglersLog> {
     AppReviewManager.get.configure(eventThreshold: 5);
 
     _userPreferenceSub = UserPreferenceManager.get.stream.listen((event) {
+      if (!mounted) {
+        return;
+      }
       if (event == UserPreferenceManager.keyThemeMode) {
-        if (!mounted) {
-          return;
-        }
         setState(() {});
         context.rebuildAllChildren();
       }

--- a/mobile/lib/pages/details_map_page.dart
+++ b/mobile/lib/pages/details_map_page.dart
@@ -97,6 +97,12 @@ class _DetailsMapPageState extends State<DetailsMapPage> {
     );
   }
 
-  void _updateAttributionMargin() =>
-      updateMapAttributionMargin(_detailsKey, widget.controller, context);
+  void _updateAttributionMargin() {
+    // Called from addPostFrameCallback, which can fire after this widget is
+    // disposed - context is only safe to use once mounted is confirmed.
+    if (!mounted) {
+      return;
+    }
+    updateMapAttributionMargin(_detailsKey, widget.controller, context);
+  }
 }

--- a/mobile/lib/pages/feedback_page.dart
+++ b/mobile/lib/pages/feedback_page.dart
@@ -9,7 +9,6 @@ import 'package:adair_flutter_lib/utils/log.dart';
 import 'package:adair_flutter_lib/utils/snack_bar.dart';
 import 'package:adair_flutter_lib/utils/string.dart';
 import 'package:adair_flutter_lib/utils/validator.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:adair_flutter_lib/widgets/checkbox_input.dart';
 import 'package:adair_flutter_lib/widgets/text_input.dart';
 import 'package:adair_flutter_lib/wrappers/device_info_wrapper.dart';
@@ -186,17 +185,20 @@ class FeedbackPageState extends State<FeedbackPage> {
     }
 
     if (!await isConnected()) {
-      safeUseContext(
-        this,
-        () => showErrorSnackBar(
-          context,
-          Strings.of(context).feedbackPageConnectionError,
-        ),
+      if (!mounted) {
+        return false;
+      }
+      showErrorSnackBar(
+        context,
+        Strings.of(context).feedbackPageConnectionError,
       );
       return false;
     }
 
-    safeUseContext(this, () => setState(() => _isSending = true));
+    if (!mounted) {
+      return false;
+    }
+    setState(() => _isSending = true);
 
     var name = _nameController.value;
     var email = _emailController.value;
@@ -265,14 +267,11 @@ class FeedbackPageState extends State<FeedbackPage> {
         reason: "Sending in-app feedback",
       );
 
-      safeUseContext(this, () {
-        showErrorSnackBar(
-          context,
-          Strings.of(context).feedbackPageErrorSending,
-        );
-
-        setState(() => _isSending = false);
-      });
+      if (!mounted) {
+        return false;
+      }
+      showErrorSnackBar(context, Strings.of(context).feedbackPageErrorSending);
+      setState(() => _isSending = false);
 
       return false;
     }

--- a/mobile/lib/pages/feedback_page.dart
+++ b/mobile/lib/pages/feedback_page.dart
@@ -195,10 +195,9 @@ class FeedbackPageState extends State<FeedbackPage> {
       return false;
     }
 
-    if (!mounted) {
-      return false;
+    if (mounted) {
+      setState(() => _isSending = true);
     }
-    setState(() => _isSending = true);
 
     var name = _nameController.value;
     var email = _emailController.value;

--- a/mobile/lib/pages/form_page.dart
+++ b/mobile/lib/pages/form_page.dart
@@ -4,7 +4,6 @@ import 'package:adair_flutter_lib/managers/subscription_manager.dart';
 import 'package:adair_flutter_lib/pages/scroll_page.dart';
 import 'package:adair_flutter_lib/res/dimen.dart';
 import 'package:adair_flutter_lib/utils/page.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:adair_flutter_lib/widgets/loading.dart';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/material.dart';
@@ -314,7 +313,10 @@ class FormPageState extends State<FormPage> {
     _formState.save();
 
     if (widget.onSave == null || await widget.onSave!()) {
-      safeUseContext(this, () => Navigator.pop(context));
+      if (!mounted) {
+        return;
+      }
+      Navigator.pop(context);
     }
   }
 }

--- a/mobile/lib/pages/main_page.dart
+++ b/mobile/lib/pages/main_page.dart
@@ -7,7 +7,6 @@ import 'package:adair_flutter_lib/managers/time_manager.dart';
 import 'package:adair_flutter_lib/utils/date_time.dart';
 import 'package:adair_flutter_lib/utils/page.dart';
 import 'package:adair_flutter_lib/utils/string.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:mobile/backup_restore_manager.dart';
@@ -91,9 +90,12 @@ class MainPageState extends State<MainPage> {
       _BarItemModel(
         iconBuilder: () => const Icon(iconBottomBarAdd),
         titleBuilder: (context) => Strings.of(context).add,
-        onTapOverride: () => showAddAnythingBottomSheet(context).then(
-          (spec) => safeUseContext(this, () => spec?.presentSavePage(context)),
-        ),
+        onTapOverride: () => showAddAnythingBottomSheet(context).then((spec) {
+          if (!mounted) {
+            return;
+          }
+          spec?.presentSavePage(context);
+        }),
       ),
       _BarItemModel(
         page: _NavigatorPage(

--- a/mobile/lib/pages/species_counter_page.dart
+++ b/mobile/lib/pages/species_counter_page.dart
@@ -3,7 +3,6 @@ import 'package:adair_flutter_lib/pages/scroll_page.dart';
 import 'package:adair_flutter_lib/res/dimen.dart';
 import 'package:adair_flutter_lib/utils/page.dart';
 import 'package:adair_flutter_lib/utils/snack_bar.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:flutter/material.dart';
 import 'package:mobile/pages/manageable_list_page.dart';
 import 'package:mobile/pages/save_trip_page.dart';
@@ -235,17 +234,17 @@ class _SpeciesCounterPageState extends State<SpeciesCounterPage> {
 
     await _tripManager.addOrUpdate(trip);
 
-    safeUseContext(
-      this,
-      () => showNoticeSnackBar(
-        context,
-        Strings.of(context).speciesCounterPageTripUpdated(
-          // Don't use displayName here (we don't want a date fallback
-          // in this case).
-          trip.hasName()
-              ? trip.name
-              : Strings.of(context).speciesCounterPageGeneralTripName,
-        ),
+    if (!mounted) {
+      return;
+    }
+    showNoticeSnackBar(
+      context,
+      Strings.of(context).speciesCounterPageTripUpdated(
+        // Don't use displayName here (we don't want a date fallback in this
+        // case).
+        trip.hasName()
+            ? trip.name
+            : Strings.of(context).speciesCounterPageGeneralTripName,
       ),
     );
   }

--- a/mobile/lib/widgets/fishing_spot_details.dart
+++ b/mobile/lib/widgets/fishing_spot_details.dart
@@ -4,7 +4,6 @@ import 'package:adair_flutter_lib/utils/dialog.dart';
 import 'package:adair_flutter_lib/utils/log.dart';
 import 'package:adair_flutter_lib/utils/page.dart';
 import 'package:adair_flutter_lib/utils/snack_bar.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:adair_flutter_lib/widgets/chip_button.dart';
 import 'package:adair_flutter_lib/wrappers/io_wrapper.dart';
 import 'package:flutter/material.dart';
@@ -346,46 +345,44 @@ class _FishingSpotActionsState extends State<_FishingSpotActions> {
       if (await urlLauncher.launch(navigationAppOptions.values.first)) {
         launched = true;
       }
-    } else {
-      await safeUseContext(this, () async {
-        // There are multiple options, give the user a choice.
-        String? url;
-        await showOurBottomSheet(
-          context,
-          (context) => BottomSheetPicker<String>(
-            onPicked: (pickedUrl) => url = pickedUrl,
-            items: navigationAppOptions,
-          ),
-        ).then((_) async {
-          // If empty, bottom sheet was dismissed.
-          if (isEmpty(url)) {
-            launched = true;
-            return;
-          }
+    } else if (mounted) {
+      // There are multiple options, give the user a choice.
+      String? url;
+      await showOurBottomSheet(
+        context,
+        (context) => BottomSheetPicker<String>(
+          onPicked: (pickedUrl) => url = pickedUrl,
+          items: navigationAppOptions,
+        ),
+      ).then((_) async {
+        // If empty, bottom sheet was dismissed.
+        if (isEmpty(url)) {
+          launched = true;
+          return;
+        }
 
-          if (url != null && url!.contains("maps.apple.com")) {
-            // TODO: Opening URLs in Safari (Apple Maps, in this case) results
-            //  in a PlatformException, even though the launch was successful.
-            //  https://github.com/flutter/flutter/issues/75691
-            try {
-              launched = await urlLauncher.launch(url!);
-            } on PlatformException {
-              launched = true;
-            }
-          } else {
+        if (url != null && url!.contains("maps.apple.com")) {
+          // TODO: Opening URLs in Safari (Apple Maps, in this case) results
+          //  in a PlatformException, even though the launch was successful.
+          //  https://github.com/flutter/flutter/issues/75691
+          try {
             launched = await urlLauncher.launch(url!);
+          } on PlatformException {
+            launched = true;
           }
-        });
+        } else {
+          launched = await urlLauncher.launch(url!);
+        }
       });
     }
 
     if (!launched) {
-      safeUseContext(
-        this,
-        () => showErrorSnackBar(
-          context,
-          Strings.of(context).mapPageErrorOpeningDirections,
-        ),
+      if (!mounted) {
+        return;
+      }
+      showErrorSnackBar(
+        context,
+        Strings.of(context).mapPageErrorOpeningDirections,
       );
     }
   }

--- a/mobile/lib/widgets/fishing_spot_map.dart
+++ b/mobile/lib/widgets/fishing_spot_map.dart
@@ -164,6 +164,9 @@ class FishingSpotMapState extends State<FishingSpotMap> {
     // Refresh state so Mapbox attribution padding is updated. This needs to be
     // done after the fishing spot widget is rendered.
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
       setState(() {});
       _updateAttributionMargin();
     });
@@ -409,15 +412,12 @@ class FishingSpotMapState extends State<FishingSpotMap> {
           context,
           requestAlways: false,
         );
-        if (!isGranted) {
+        if (!isGranted || !mounted) {
           return;
         }
 
         var currentLocation = _locationMonitor.currentLatLng;
         if (currentLocation == null) {
-          if (!mounted) {
-            return;
-          }
           showErrorSnackBar(
             context,
             Strings.of(context).mapPageErrorGettingLocation,

--- a/mobile/lib/widgets/fishing_spot_map.dart
+++ b/mobile/lib/widgets/fishing_spot_map.dart
@@ -615,6 +615,12 @@ class FishingSpotMapState extends State<FishingSpotMap> {
   }
 
   void _updateAttributionMargin() {
+    // Called from addPostFrameCallback, which can fire after this widget is
+    // disposed (see the safeUseContext call sites above) - context is only
+    // safe to use once mounted is confirmed.
+    if (!mounted) {
+      return;
+    }
     updateMapAttributionMargin(_fishingSpotKey, _mapController, context);
   }
 

--- a/mobile/lib/widgets/fishing_spot_map.dart
+++ b/mobile/lib/widgets/fishing_spot_map.dart
@@ -7,7 +7,6 @@ import 'package:adair_flutter_lib/res/dimen.dart';
 import 'package:adair_flutter_lib/utils/log.dart';
 import 'package:adair_flutter_lib/utils/page.dart';
 import 'package:adair_flutter_lib/utils/snack_bar.dart';
-import 'package:adair_flutter_lib/utils/widget.dart';
 import 'package:adair_flutter_lib/widgets/animated_visibility.dart';
 import 'package:adair_flutter_lib/wrappers/io_wrapper.dart';
 import 'package:collection/collection.dart' show IterableExtension;
@@ -416,12 +415,12 @@ class FishingSpotMapState extends State<FishingSpotMap> {
 
         var currentLocation = _locationMonitor.currentLatLng;
         if (currentLocation == null) {
-          safeUseContext(
-            this,
-            () => showErrorSnackBar(
-              context,
-              Strings.of(context).mapPageErrorGettingLocation,
-            ),
+          if (!mounted) {
+            return;
+          }
+          showErrorSnackBar(
+            context,
+            Strings.of(context).mapPageErrorGettingLocation,
           );
         } else {
           setState(() => _myLocationEnabled = true);
@@ -616,8 +615,7 @@ class FishingSpotMapState extends State<FishingSpotMap> {
 
   void _updateAttributionMargin() {
     // Called from addPostFrameCallback, which can fire after this widget is
-    // disposed (see the safeUseContext call sites above) - context is only
-    // safe to use once mounted is confirmed.
+    // disposed - context is only safe to use once mounted is confirmed.
     if (!mounted) {
       return;
     }
@@ -917,18 +915,19 @@ class FishingSpotMapState extends State<FishingSpotMap> {
 
     // The map may be refreshed while being disposed (for example, as part of
     // a listener being notified). Ensure it is still safe to update.
-    safeUseContext(this, () {
-      setState(() {
-        _activeSymbol = newActiveSymbol;
-        _isDismissingFishingSpot = newIsDismissingFishingSpot;
-        _oldFishingSpot = newOldFishingSpot;
-      });
-      // Must be done in an addPostFrameCallback because the attribution's
-      // padding depends on a post-rendered widget.
-      WidgetsBinding.instance.addPostFrameCallback(
-        (_) => _updateAttributionMargin(),
-      );
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _activeSymbol = newActiveSymbol;
+      _isDismissingFishingSpot = newIsDismissingFishingSpot;
+      _oldFishingSpot = newOldFishingSpot;
     });
+    // Must be done in an addPostFrameCallback because the attribution's
+    // padding depends on a post-rendered widget.
+    WidgetsBinding.instance.addPostFrameCallback(
+      (_) => _updateAttributionMargin(),
+    );
   }
 
   void _setupPickerIfNeeded() {

--- a/mobile/test/widget/fishing_spot_map_test.dart
+++ b/mobile/test/widget/fishing_spot_map_test.dart
@@ -1092,11 +1092,23 @@ void main() {
 
     // Let selection resume far enough to schedule the addPostFrameCallback
     // that updates the attribution margin, while the widget is still
-    // mounted.
+    // mounted. A microtask drain (rather than tester.pump()) is required
+    // here so the scheduled callback doesn't fire yet - pumping a frame
+    // would run it while the widget is still mounted, defeating the point
+    // of this test. The count below is a generous upper bound on the number
+    // of microtask hops between updateCompleter completing and
+    // _selectFishingSpot reaching its addPostFrameCallback call.
+    const selectFishingSpotResumeMicrotaskHops = 5;
     updateCompleter.complete();
-    for (var i = 0; i < 5; i++) {
+    for (var i = 0; i < selectFishingSpotResumeMicrotaskHops; i++) {
       await Future<void>.value();
     }
+
+    // Confirm selection actually resumed and scheduled a frame (via the
+    // setState just before addPostFrameCallback is registered), rather
+    // than this test passing vacuously because dispose happened before
+    // that point was ever reached.
+    expect(tester.binding.hasScheduledFrame, isTrue);
 
     // Remove the widget, as if the user navigated away, before the
     // scheduled post-frame callback fires.

--- a/mobile/test/widget/fishing_spot_map_test.dart
+++ b/mobile/test/widget/fishing_spot_map_test.dart
@@ -26,6 +26,7 @@ import 'package:mobile/widgets/widget.dart';
 import 'package:mockito/mockito.dart';
 
 import '../../../../adair-flutter-lib/test/test_utils/finder.dart';
+import '../../../../adair-flutter-lib/test/test_utils/testable.dart';
 import '../../../../adair-flutter-lib/test/test_utils/widget.dart';
 import '../mocks/mocks.mocks.dart';
 import '../mocks/stubbed_managers.dart';
@@ -1052,6 +1053,56 @@ void main() {
 
     final annotation = result.captured.first as PointAnnotation;
     expect(annotation.iconImage, "active-pin");
+  });
+
+  testWidgets("Attribution margin update after dispose doesn't crash", (
+    tester,
+  ) async {
+    var fishingSpot = FishingSpot(
+      id: randomId(),
+      name: "Spot 1",
+      lat: 1,
+      lng: 2,
+    );
+    when(managers.fishingSpotManager.list()).thenReturn([fishingSpot]);
+
+    // Controls when the symbol update finishes, so the widget can be
+    // disposed while selection is still in progress.
+    var updateCompleter = Completer<void>();
+    when(
+      mapController.map.pointAnnotationManager.update(any),
+    ).thenAnswer((_) => updateCompleter.future);
+
+    await pumpMapWrapper(tester, FishingSpotMap());
+
+    // Start selecting a fishing spot; this suspends on the point annotation
+    // update above, before the attribution margin update is scheduled.
+    expect(mapController.value.onSymbolTappedCallbacks.isEmpty, isFalse);
+    mapController.value.onSymbolTappedCallbacks.first(
+      Symbol(
+        id: randomId().uuid,
+        options: SymbolOptions(
+          latLng: fishingSpot.latLng,
+          pin: .active,
+          iconSize: 1.5,
+        ),
+        metadata: SymbolMetadata(fishingSpot: fishingSpot),
+      ),
+    );
+
+    // Let selection resume far enough to schedule the addPostFrameCallback
+    // that updates the attribution margin, while the widget is still
+    // mounted.
+    updateCompleter.complete();
+    for (var i = 0; i < 5; i++) {
+      await Future<void>.value();
+    }
+
+    // Remove the widget, as if the user navigated away, before the
+    // scheduled post-frame callback fires.
+    await tester.pumpWidget(Testable((_) => const SizedBox()));
+
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets("Editing selected spot updates fishing spot widget", (


### PR DESCRIPTION
## Summary
- Fixes a fatal crash: `FishingSpotMapState._updateAttributionMargin()` accessed `context` unconditionally, even though it's invoked from an `addPostFrameCallback` scheduled inside a `safeUseContext` block.
- `safeUseContext` (marked `@Deprecated("Don't use, can cause false sense of security")` in `adair-flutter-lib`) only checks `mounted` at the moment it's called — not when the callback it schedules actually runs, a frame later. If the widget is disposed in that window (e.g. the user backs out of the map right after tapping a fishing spot), the deferred callback fires against an unmounted `State`, and `context` throws a null-check.
- Added `if (!mounted) { return; }` at the top of `_updateAttributionMargin()`, which is the shared call site for both `addPostFrameCallback` schedulers in this widget (`initState` and `_selectFishingSpot`).
- **Follow-up**: replaced every other `safeUseContext` call site in the app (8 files, 10 call sites total) with an inline `mounted` check, since this is a common source of this exact class of crash and `safeUseContext`'s own deprecation notice warns against relying on it. `safeUseContext` itself now has no remaining callers in this repo.

## Why the crash happens
`_selectFishingSpot` (fishing_spot_map.dart) does its work, then calls `safeUseContext(this, () { setState(...); WidgetsBinding.instance.addPostFrameCallback((_) => _updateAttributionMargin()); })`. `safeUseContext` confirms `mounted` before running that closure, so the `addPostFrameCallback` *registration* is safe — but the callback itself doesn't run until the next drawn frame. If the widget is disposed in the interim, the callback executes anyway (postFrameCallbacks are a `SchedulerBinding`-level queue, not tied to the widget that scheduled them), and `_updateAttributionMargin` calls `context`, which is a null-check getter (`_element!`) on the framework's `State` class — throwing `Null check operator used on a null value` once `_element` is null after disposal.

## Reproduction steps
1. Open the map and tap a fishing spot to select it (starts `_selectFishingSpot`, which does async work — symbol lookup/update, camera move — before scheduling the attribution-margin update on the next frame).
2. Navigate away from the map (e.g. back button) before that next frame renders.
3. The pending `addPostFrameCallback` fires against the now-disposed `FishingSpotMapState`, crashing with a null-check on `context`.

This matches the crash's stack trace exactly: `_selectFishingSpot.<fn>.<fn>` (the `safeUseContext` closure's nested `addPostFrameCallback` closure) → `_updateAttributionMargin` → `State.context`.

## Crashlytics issue
`1f4b4a0105e398073c6e60b6208c701c` — fatal, Android, first seen 2.7.15, last seen 2.7.19.

## safeUseContext cleanup
The other 9 call sites (`main.dart`, `entity_manager.dart`, `pages/main_page.dart`, `pages/form_page.dart`, `pages/feedback_page.dart` ×3, `pages/species_counter_page.dart`, `widgets/fishing_spot_details.dart` ×2) were all schedule-time-only checks of the same shape — safe for a direct `await`-then-use, but a latent version of this bug wherever the guarded closure itself schedules further async work (a `.then()`, another `addPostFrameCallback`, etc.). Replaced each with an inline `if (!mounted) { return; }` at the point `context` is actually used, which is both more explicit and correct in the same cases `safeUseContext` wasn't. No behavior change for any call site that was already safe.

`safeUseContext` in `adair-flutter-lib` is now unused across the app (confirmed not referenced in `pro-iq` or `activity-log` either). Not removing the helper itself here since that's a shared-lib change outside this repo; flagged separately.

## Test plan
- Added a widget test that selects a fishing spot (holding the underlying point-annotation update on a `Completer` to control timing), lets the `addPostFrameCallback` get scheduled while still mounted, then disposes the widget before that callback fires — reproducing the exact race.
- Confirmed the test fails with the same "context after dispose" error when the fix is reverted, and passes with the fix applied.
- Ran the full test suites for every file touched by the `safeUseContext` cleanup (`main_test.dart`, `entity_manager_test.dart`, `fishing_spot_details_test.dart`, `main_page_test.dart`, `form_page_test.dart`, `species_counter_page_test.dart`, `feedback_page_test.dart`, `fishing_spot_map_test.dart`) — 252 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)